### PR TITLE
replace with ImmutableMaps

### DIFF
--- a/src/test/java/io/castle/client/AbstractCastleHttpLayerTest.java
+++ b/src/test/java/io/castle/client/AbstractCastleHttpLayerTest.java
@@ -13,6 +13,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class AbstractCastleHttpLayerTest {
@@ -31,7 +32,7 @@ public abstract class AbstractCastleHttpLayerTest {
     public void prepare() throws NoSuchFieldException, IllegalAccessException, CastleSdkConfigurationException, IOException {
         //Given a mocked API server
         server = new MockWebServer();
-        server.start();
+        server.start(InetAddress.getByName("127.0.0.1"),0);
         //Given a SDK instance
         sdk = new Castle(CastleSdkInternalConfiguration.getInternalConfiguration());
         CastleConfiguration configuration = sdk.getInternalConfiguration().getConfiguration();

--- a/src/test/java/io/castle/client/AbstractCastleHttpLayerTest.java
+++ b/src/test/java/io/castle/client/AbstractCastleHttpLayerTest.java
@@ -78,49 +78,4 @@ public abstract class AbstractCastleHttpLayerTest {
         Assertions.assertThat(value).isNotNull();
         return value;
     }
-
-
-    public static class CustomAppProperties {
-        private String a;
-        private int b;
-
-        public String getA() {
-            return a;
-        }
-
-        public void setA(String a) {
-            this.a = a;
-        }
-
-        public int getB() {
-            return b;
-        }
-
-        public void setB(int b) {
-            this.b = b;
-        }
-    }
-
-    public static class CustomAppTraits {
-        private String x;
-        private int y;
-
-        public String getX() {
-            return x;
-        }
-
-        public void setX(String x) {
-            this.x = x;
-        }
-
-        public int getY() {
-            return y;
-        }
-
-        public void setY(int y) {
-            this.y = y;
-        }
-    }
-
-
 }

--- a/src/test/java/io/castle/client/CastleAuthenticateHttpTest.java
+++ b/src/test/java/io/castle/client/CastleAuthenticateHttpTest.java
@@ -10,6 +10,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import com.google.common.collect.ImmutableMap;
+
 import javax.servlet.http.HttpServletRequest;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -87,10 +89,12 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
                 Assertions.fail("error on request", exception);
             }
         };
-        CustomAppProperties properties = new CustomAppProperties();
-        CustomAppTraits traits = new CustomAppTraits();
         // and an authenticate request is made
-        sdk.onRequest(request).authenticateAsync(event, id, properties, traits, handler);
+        sdk.onRequest(request).authenticateAsync(event, id, ImmutableMap.builder()
+                .put("b",0)
+                .build(), ImmutableMap.builder()
+                .put("y",0)
+                .build(), handler);
 
         // then
         RecordedRequest recordedRequest = server.takeRequest();
@@ -214,16 +218,15 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
 
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
-        CustomAppProperties properties = new CustomAppProperties();
-        properties.setA("valueA");
-        properties.setB(123456);
-
-        CustomAppTraits traits = new CustomAppTraits();
-        traits.setX("valueX");
-        traits.setY(654321);
 
         // and an authenticate request is made
-        Verdict verdict = sdk.onRequest(request).authenticate(event, id, properties, traits);
+        Verdict verdict = sdk.onRequest(request).authenticate(event, id, ImmutableMap.builder()
+                .put("a","valueA")
+                .put("b",123456)
+                .build(), ImmutableMap.builder()
+                .put("x","valueX")
+                .put("y",654321)
+                .build());
 
         // then
         Verdict expected = VerdictBuilder.success()
@@ -247,12 +250,12 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
 
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
-        CustomAppProperties properties = new CustomAppProperties();
-        properties.setA("valueA");
-        properties.setB(123456);
 
         // and an authenticate request is made
-        Verdict verdict = sdk.onRequest(request).authenticate(event, id, properties, null);
+        Verdict verdict = sdk.onRequest(request).authenticate(event, id, ImmutableMap.builder()
+                .put("a","valueA")
+                .put("b",123456)
+                .build(), null);
 
         // then a exception is send to the client code because of bad response from the castle backend
     }
@@ -266,12 +269,12 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
 
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
-        CustomAppProperties properties = new CustomAppProperties();
-        properties.setA("valueA");
-        properties.setB(123456);
 
         // and an authenticate request is made
-        Verdict verdict = sdk.onRequest(request).authenticate(event, id, properties, null);
+        Verdict verdict = sdk.onRequest(request).authenticate(event, id, ImmutableMap.builder()
+                .put("a","valueA")
+                .put("b",123456)
+                .build(), null);
 
         // then
         Verdict expected = VerdictBuilder.failover("Client Error")
@@ -306,12 +309,12 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
 
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
-        CustomAppProperties properties = new CustomAppProperties();
-        properties.setA("valueA");
-        properties.setB(123456);
 
         // and an authenticate request is made
-        Verdict verdict = sdk.onRequest(request).authenticate(event, id, properties, null);
+        Verdict verdict = sdk.onRequest(request).authenticate(event, id, ImmutableMap.builder()
+                .put("a","valueA")
+                .put("b",123456)
+                .build(), null);
 
         // then a illegal json failover is provided
         Verdict expected = VerdictBuilder.failover("Illegal json format")

--- a/src/test/java/io/castle/client/CastleIdentifyHttpTest.java
+++ b/src/test/java/io/castle/client/CastleIdentifyHttpTest.java
@@ -9,6 +9,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import com.google.common.collect.ImmutableMap;
+
 import javax.servlet.http.HttpServletRequest;
 
 public class CastleIdentifyHttpTest extends AbstractCastleHttpLayerTest {
@@ -43,14 +45,13 @@ public class CastleIdentifyHttpTest extends AbstractCastleHttpLayerTest {
 
         // and a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
-
-        // and
-        CustomAppTraits traits = new CustomAppTraits();
-        traits.setX("valueX");
-        traits.setY(234567);
+                
 
         // when an identify request is made with a traits object
-        sdk.onRequest(request).identify(id, traits);
+        sdk.onRequest(request).identify(id, ImmutableMap.builder()
+                .put("x", "valueX")
+                .put("y", 234567)
+                .build());
 
         // then the json match specification
         RecordedRequest recordedRequest = server.takeRequest();
@@ -67,13 +68,11 @@ public class CastleIdentifyHttpTest extends AbstractCastleHttpLayerTest {
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
 
-        // And
-        CustomAppTraits traits = new CustomAppTraits();
-        traits.setX("valueX");
-        traits.setY(234567);
-
         // when an identify request is made with a traits object and active option
-        sdk.onRequest(request).identify(id, traits, false);
+        sdk.onRequest(request).identify(id,  ImmutableMap.builder()
+                .put("x", "valueX")
+                .put("y", 234567)
+                .build(), false);
 
         // then
         RecordedRequest recordedRequest = server.takeRequest();
@@ -90,13 +89,11 @@ public class CastleIdentifyHttpTest extends AbstractCastleHttpLayerTest {
         // and a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
 
-        //and
-        CustomAppTraits traits = new CustomAppTraits();
-        traits.setX("valueX");
-        traits.setY(234567);
-
         // when an identify request is made with a traits object
-        sdk.onRequest(request).identify(id, traits);
+        sdk.onRequest(request).identify(id,  ImmutableMap.builder()
+                .put("x", "valueX")
+                .put("y", 234567)
+                .build());
 
         // then no exceptions are throw
     }

--- a/src/test/java/io/castle/client/CastleMergeHttpTest.java
+++ b/src/test/java/io/castle/client/CastleMergeHttpTest.java
@@ -9,6 +9,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import com.google.common.collect.ImmutableMap;
+
 import javax.servlet.http.HttpServletRequest;
 
 public class CastleMergeHttpTest extends AbstractCastleHttpLayerTest {
@@ -31,13 +33,12 @@ public class CastleMergeHttpTest extends AbstractCastleHttpLayerTest {
         customExtraContext.setAddString("String value");
         customExtraContext.setCondition(true);
         customExtraContext.setValue(10L);
-        // and traits object
-        CustomAppTraits traits = new CustomAppTraits();
-        traits.setX("valueX");
-        traits.setY(234567);
 
         // and an authenticate request is made
-        sdk.onRequest(request).mergeContext(customExtraContext).identify(id, traits);
+        sdk.onRequest(request).mergeContext(customExtraContext).identify(id, ImmutableMap.builder()
+                .put("x", "valueX")
+                .put("y", 234567)
+                .build());
         //When
 
         //Then the json send contains a extended context object

--- a/src/test/java/io/castle/client/CastleTrackHttpTest.java
+++ b/src/test/java/io/castle/client/CastleTrackHttpTest.java
@@ -12,6 +12,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import com.google.common.collect.ImmutableMap;
+
 import javax.servlet.http.HttpServletRequest;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -71,13 +73,11 @@ public class CastleTrackHttpTest extends AbstractCastleHttpLayerTest {
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
 
-        // And
-        CustomAppProperties properties = new CustomAppProperties();
-        properties.setA("valueA");
-        properties.setB(123456);
-
         // and an track request is made
-        sdk.onRequest(request).track(event, userId, reviewId, properties);
+        sdk.onRequest(request).track(event, userId, reviewId, ImmutableMap.builder()
+                .put("a","valueA")
+                .put("b",123456)
+                .build());
 
         // then
         RecordedRequest recordedRequest = server.takeRequest();
@@ -96,17 +96,14 @@ public class CastleTrackHttpTest extends AbstractCastleHttpLayerTest {
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
 
-        // And
-        CustomAppProperties properties = new CustomAppProperties();
-        properties.setA("valueA");
-        properties.setB(123456);
-
-        CustomAppTraits traits = new CustomAppTraits();
-        traits.setX("x value");
-        traits.setY(2342);
-
         // and an track request is made
-        sdk.onRequest(request).track(event, userId, reviewId,properties, traits);
+        sdk.onRequest(request).track(event, userId, reviewId, ImmutableMap.builder()
+                .put("a","valueA")
+                .put("b",123456)
+                .build(), ImmutableMap.builder()
+                .put("x", "x value")
+                .put("y", 2342)
+                .build());
 
         // then
         RecordedRequest recordedRequest = server.takeRequest();


### PR DESCRIPTION
We want to use `ImmutableMap` as we think it makes for a cleaner example. Could you check for any styling errors?