### PR TITLE
Easier configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ When using Maven, add the following dependency to your `pom.xml` file:
 
 ## Initialize the SDK
 
-Go to the settings page of your Castle account and find your **API Secret** and (optionally) your **APP ID**.
+Go to the settings page of your Castle account and find your **API Secret**
 
 **Alt 1. Initialize using ENV variables**
 
-On initialization the Castle SDK will look for the secret in the `CASTLE_SDK_API_SECRET` environment variable. If it is set, no options needs to be passed to the initializer.
+On initialization the Castle SDK will look for the secret in the `CASTLE_API_SECRET` environment variable. If it is set, no options needs to be passed to the initializer.
 
 ```java
 Castle.initialize();
@@ -94,18 +94,11 @@ To use the library on a java 7 environment, switch the guava library to the foll
 ## Settings
 
 Before running an application that uses the Castle Java SDK,
-there is one that must be configured.
-This is:
+there is one that must be configured:
 
  * **API Secret**: a secret that will be used for authentication purposes.
 
-If the API Secret is not provided, the client's initialization process will fail.
-
-Similar to that, there is also another setting associated to a Castle account.
-
- * **App ID**: an application identifier associated with a valid Castle account.
-
-Both of them can be found in the settings page of a Castle account.
+If the API Secret is not provided, the client's initialization process will fail. It can be found in the settings page of the Castle dashboard.
 
 Besides the aforementioned settings, the following are other application-level setting
 that can be optionally configured:
@@ -140,8 +133,7 @@ Finally, it also contains the environmental variable that can be used instead of
 
 Setting | Default values, when they exist | Properties file key | Environmental variable |
 --- | --- | --- | --- |
-App ID |   | `app_id` | `CASTLE_SDK_APP_ID` |
-API Secret |   | `api_secret` | `CASTLE_SDK_API_SECRET` |
+API Secret |   | `api_secret` | `CASTLE_API_SECRET` |
 Whitelisted Headers | `User-Agent,Accept-Language,Accept-Encoding,Accept-Charset,Accept,Accept-Datetime,X-Forwarded-For,Forwarded,X-Forwarded,X-Real-IP,REMOTE_ADDR` | `white_list` | `CASTLE_SDK_WHITELIST_HEADERS` |
 Blacklisted Headers | `Cookie` | `black_list` | `CASTLE_SDK_BLACKLIST_HEADERS` |
 Timeout | `500` | `timeout` | `CASTLE_SDK_TIMEOUT` |
@@ -157,7 +149,6 @@ The following is a sample Java Properties file containing all of the settings th
 modified:
 
 ```properties
-app_id=
 api_secret=
 white_list=User-Agent,Accept-Language,Accept-Encoding,Accept-Charset,Accept,Accept-Datetime,X-Forwarded-For,Forwarded,X-Forwarded,X-Real-IP,REMOTE_ADDR
 black_list=Cookie

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ configuration builder initialized with default settings.
 Castle.initialize(
   Castle.configurationBuilder()
     .apiSecret("abcd")
+    .build()
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,6 @@
 # Java SDK for Castle
 
-**[Castle](https://castle.io) adds real-time monitoring of your authentication stack,
-instantly notifying you and your users on potential account hijacks.**
-
-To generate the javadoc documentation run:
-
-    mvn clean compile javadoc:javadoc
-
-The javadoc will be located inside the `target/site` directory.
-
-To check test coverage run:
-
-    mvn clean test jacoco:report
-
-The coverage report will be on the page `target/jacoco-ut/index.html`
-
-# Development branch
-
-Branch for development process. The castle-java-example application have a parallel dev branch for test proposes.
-
-To use on example application dev branch, first install locally:
-
-    mvn clean install
-
+**[Castle](https://castle.io) analyzes device, location, and interaction patterns in your web and mobile apps and lets you stop account takeover attacks in real-time.**
 
 # Quickstart
 
@@ -35,44 +13,56 @@ When using Maven, add the following dependency to your `pom.xml` file:
         </dependency>
 ```
 
+## Initialize the SDK
+
 Go to the settings page of your Castle account and find your **API Secret** and (optionally) your **APP ID**.
-Then create a new file named `castle_sdk.properties` with the following content:
 
-```properties
-app_id=<API_Secret>
-api_secret=<APP_ID>
+**Alt 1. Initialize using ENV variables**
 
+On initialization the Castle SDK will look for the secret in `CASTLE_SDK_API_SECRET`.
+If that is set, no options needs to be passed to the initialization.
+
+```java
+Castle.initialize();
+```
+
+**Alt 2. Initialize using configuration builder**
+
+If you don't use ENV variables, you can set the secret programatically by using
+a `CastleConfigurationBuilder`. `Castle.configurationBuilder()` returns a
+configuration builder initialized with default settings.
+
+```java
+Castle.initialize(
+  Castle.configurationBuilder()
+    .apiSecret("abcd")
+);
 ```
 
 All other settings will be set to their default values.
 
-Place the file in your classpath (for instance in `src/main/resources`).
+## Tracking events
 
-Next, the SDK must be properly initialized, so that some configuration errors are discovered early.
-Make sure this line of code is executed once during the initialization of the application using the SDK:
-
-```java
-Castle.verifySdkConfigurationAndInitialize();
-```
-
-Once the SDK has been initialized, it suffices to get an instance of the `io.castle.client.api.CastleApi` interface
-in the following manner:
+Once the SDK has been initialized, tracking requests are sent through the SDK
+instance.
 
 ```java
-CastleApi newAPIRef = Castle.sdk().onRequest(req)
-```
+// `req` is an instance of `HttpServletRequest`.
+CastleApi castle = Castle.sdk().onRequest(req);
 
-Here `req` is an instance of `HttpServletRequest`.
+castle.track("$login.succeeded", "<user_id>");
+```
 
 Note that the `req` instance should be bound to the underlying request in order to extract the necessary information.
 It means that a safe place to create the `CastleApi` instance is the request handling thread. After creation the
 `CastleApi` instance can be passed to any thread independently of the original thread life cycle.
 
-When using Castle.js, calculate a SHA-256 HMAC in hex format using the following javascript code when calling identify:
+## Castle Javascript secure mode
 
+When using Castle.js, secure mode can be enabled with the following helper:
 ```
-                _castle('secure',
-                    '<%= Castle.sdk().secureUserID(someUserID) %>');
+_castle('secure',
+    '<%= Castle.sdk().secureUserID(someUserID) %>');
 ```
 
 ## Java 7 configuration
@@ -96,17 +86,6 @@ To use the library on a java 7 environment, switch the guava library to the foll
             <version>23.0-android</version>
         </dependency>
 ```
-
-
-# Where to Find Documentation
-
-The official Castle [documentation](https://castle.io/docs) documents all possible use cases of the API.
-It also contains information on support for other platforms.
-
-This file contains a guide that should get you started as quickly as possible with the Java SDK.
-There is also available a Javadoc.
-Furthermore, there is a [sample application](https://github.com/castle/castle-java-example)
-using Java Servlets and this SDK.
 
 # Configuring the SDK
 
@@ -524,3 +503,35 @@ The track call enables users to specify a custom instance of `io.castle.client.m
 In such case, the behaviour is to call the handler's `onResponse` method with `true` as value and then return without making any request to the Castle API.
 * **Identify**: the method returns immediately and no request is made.
 * **Review**: not applicable.
+
+# Documentation
+
+The official Castle [documentation](https://castle.io/docs) documents all possible use cases of the API.
+It also contains information on support for other platforms.
+
+This file contains a guide that should get you started as quickly as possible with the Java SDK.
+There is also available a Javadoc.
+Furthermore, there is a [sample application](https://github.com/castle/castle-java-example)
+using Java Servlets and this SDK.
+
+To generate the javadoc documentation run:
+
+    mvn clean compile javadoc:javadoc
+
+The javadoc will be located inside the `target/site` directory.
+
+To check test coverage run:
+
+    mvn clean test jacoco:report
+
+The coverage report will be on the page `target/jacoco-ut/index.html`
+
+# Development branch
+
+Branch for development process. The castle-java-example application have a parallel dev branch for test proposes.
+
+To use on example application dev branch, first install locally:
+
+    mvn clean install
+
+

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Go to the settings page of your Castle account and find your **API Secret** and 
 
 **Alt 1. Initialize using ENV variables**
 
-On initialization the Castle SDK will look for the secret in `CASTLE_SDK_API_SECRET`.
-If that is set, no options needs to be passed to the initialization.
+On initialization the Castle SDK will look for the secret in the `CASTLE_SDK_API_SECRET` environment variable. If it is set, no options needs to be passed to the initializer.
 
 ```java
 Castle.initialize();

--- a/src/main/java/io/castle/client/Castle.java
+++ b/src/main/java/io/castle/client/Castle.java
@@ -71,13 +71,13 @@ public class Castle {
     /**
      * Initialize and configure the Castle SDK using a configuration builder object
      *
-     * @param builder CastleConfigurationBuilder object
+     * @param config CastleConfiguration object
      * @throws CastleSdkConfigurationException Configuration options missing or
      *   invalid
      */
-    public static synchronized void initialize(CastleConfigurationBuilder builder) throws CastleSdkConfigurationException {
+    public static synchronized void initialize(CastleConfiguration config) throws CastleSdkConfigurationException {
         instance = new Castle(
-            CastleSdkInternalConfiguration.buildFromConfiguration(builder.build())
+            CastleSdkInternalConfiguration.buildFromConfiguration(config)
         );
     }
 
@@ -88,7 +88,7 @@ public class Castle {
      *   invalid
      */
     public static void initialize() throws CastleSdkConfigurationException {
-        initialize(configurationBuilder());
+        initialize(configurationBuilder().build());
     }
 
     public static CastleConfigurationBuilder configurationBuilder() {

--- a/src/main/java/io/castle/client/Castle.java
+++ b/src/main/java/io/castle/client/Castle.java
@@ -49,7 +49,7 @@ public class Castle {
      */
     public static Castle sdk() throws IllegalStateException {
         if (instance == null) {
-            throw new IllegalStateException("Castle SDK must be initialized via a call to verifySdkConfigurationAndInitialize");
+            throw new IllegalStateException("Castle SDK must be initialized. Call `Castle.initialize()` first");
         }
         return instance;
     }
@@ -69,7 +69,7 @@ public class Castle {
     }
 
     /**
-     * Initialize and configure the Castle SDK using a configuration builder object
+     * Initialize and configure the Castle SDK using a configuration object
      *
      * @param config CastleConfiguration object
      * @throws CastleSdkConfigurationException Configuration options missing or

--- a/src/main/java/io/castle/client/Castle.java
+++ b/src/main/java/io/castle/client/Castle.java
@@ -4,6 +4,7 @@ import com.google.common.hash.HashFunction;
 import io.castle.client.api.CastleApi;
 import io.castle.client.internal.CastleApiImpl;
 import io.castle.client.internal.config.CastleConfiguration;
+import io.castle.client.internal.config.CastleConfigurationBuilder;
 import io.castle.client.internal.config.CastleSdkInternalConfiguration;
 import io.castle.client.model.CastleSdkConfigurationException;
 import org.slf4j.Logger;
@@ -67,6 +68,32 @@ public class Castle {
         instance = new Castle(loadedConfig);
     }
 
+    /**
+     * Initialize and configure the Castle SDK using a configuration builder object
+     *
+     * @param builder CastleConfigurationBuilder object
+     * @throws CastleSdkConfigurationException Configuration options missing or
+     *   invalid
+     */
+    public static synchronized void initialize(CastleConfigurationBuilder builder) throws CastleSdkConfigurationException {
+        instance = new Castle(
+            CastleSdkInternalConfiguration.buildFromConfiguration(builder.build())
+        );
+    }
+
+    /**
+     * Initialize the Castle SDK using default settings and variables from ENV
+     *
+     * @throws CastleSdkConfigurationException Configuration options missing or
+     *   invalid
+     */
+    public static void initialize() throws CastleSdkConfigurationException {
+        initialize(configurationBuilder());
+    }
+
+    public static CastleConfigurationBuilder configurationBuilder() {
+        return CastleSdkInternalConfiguration.builderFromConfigurationLoader();
+    }
 
     /**
      * Create a API context for the given request.
@@ -107,7 +134,6 @@ public class Castle {
     CastleSdkInternalConfiguration getInternalConfiguration() {
         return internalConfiguration;
     }
-
 
     /**
      * Calculate the secure userId HMAC using the internal API Secret.

--- a/src/main/java/io/castle/client/internal/config/CastleConfigurationBuilder.java
+++ b/src/main/java/io/castle/client/internal/config/CastleConfigurationBuilder.java
@@ -278,6 +278,11 @@ public class CastleConfigurationBuilder {
         return this;
     }
 
+    /* alias for withApiSecret  */
+    public CastleConfigurationBuilder apiSecret(String apiSecret) {
+        return withApiSecret(apiSecret);
+    }
+
     /**
      * Validates and returns a configuration object, if all required fields have the required values, or an exception
      * otherwise.
@@ -345,6 +350,10 @@ public class CastleConfigurationBuilder {
         return this;
     }
 
+    public CastleConfigurationBuilder appId(String appId) {
+        return withCastleAppId(appId);
+    }
+
     /**
      * Sets the HTTP layer that will be used for making calls to the Castle REST API.
      *
@@ -378,4 +387,8 @@ public class CastleConfigurationBuilder {
         return this;
     }
 
+    /* alias for logHttpRequests */
+    public CastleConfigurationBuilder enableHttpLogging(Boolean logHttpRequests) {
+        return withLogHttpRequests(logHttpRequests);
+    }
 }

--- a/src/main/java/io/castle/client/internal/config/CastleSdkInternalConfiguration.java
+++ b/src/main/java/io/castle/client/internal/config/CastleSdkInternalConfiguration.java
@@ -33,6 +33,16 @@ public class CastleSdkInternalConfiguration {
         return new CastleSdkInternalConfiguration(apiFactory, modelInstance, configuration);
     }
 
+    public static CastleSdkInternalConfiguration buildFromConfiguration(CastleConfiguration config) {
+        CastleGsonModel modelInstance = new CastleGsonModel();
+        RestApiFactory apiFactory = loadRestApiFactory(modelInstance, config);
+        return new CastleSdkInternalConfiguration(apiFactory, modelInstance, config);
+    }
+
+    public static CastleConfigurationBuilder builderFromConfigurationLoader() {
+        return new ConfigurationLoader().loadConfigurationBuilder();
+    }
+
     /**
      * Currently only the okHttp backend is available.
      *

--- a/src/main/java/io/castle/client/internal/config/ConfigurationLoader.java
+++ b/src/main/java/io/castle/client/internal/config/ConfigurationLoader.java
@@ -87,6 +87,11 @@ class ConfigurationLoader {
      *                                         parsable into an int
      */
     public CastleConfiguration loadConfiguration() throws CastleSdkConfigurationException, NumberFormatException {
+        CastleConfigurationBuilder builder = loadConfigurationBuilder();
+        return builder.build();
+    }
+
+    public CastleConfigurationBuilder loadConfigurationBuilder() {
         String envApiSecret = loadConfigurationValue(
                 castleConfigurationProperties,
                 "api_secret",
@@ -173,7 +178,8 @@ class ConfigurationLoader {
         if (logHttpRequests != null) {
             builder.withLogHttpRequests(Boolean.valueOf(logHttpRequests));
         }
-        return builder.build();
+
+        return builder;
     }
 
     private String loadConfigurationValue(Properties properties, String propertyName, String environmentName) {

--- a/src/main/java/io/castle/client/internal/config/ConfigurationLoader.java
+++ b/src/main/java/io/castle/client/internal/config/ConfigurationLoader.java
@@ -95,8 +95,16 @@ class ConfigurationLoader {
         String envApiSecret = loadConfigurationValue(
                 castleConfigurationProperties,
                 "api_secret",
-                "CASTLE_SDK_API_SECRET"
+                "CASTLE_API_SECRET"
         );
+        // Legacy env name for secret
+        if (envApiSecret == null) {
+            envApiSecret = loadConfigurationValue(
+                    castleConfigurationProperties,
+                    "api_secret",
+                    "CASTLE_SDK_API_SECRET"
+            );
+        }
         String castleAppId = loadConfigurationValue(
                 castleConfigurationProperties,
                 "app_id",

--- a/src/test/java/io/castle/client/CastleIdentifyHttpTest.java
+++ b/src/test/java/io/castle/client/CastleIdentifyHttpTest.java
@@ -45,7 +45,7 @@ public class CastleIdentifyHttpTest extends AbstractCastleHttpLayerTest {
 
         // and a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
-                
+
 
         // when an identify request is made with a traits object
         sdk.onRequest(request).identify(id, ImmutableMap.builder()

--- a/src/test/java/io/castle/client/CastleTest.java
+++ b/src/test/java/io/castle/client/CastleTest.java
@@ -82,11 +82,45 @@ public class CastleTest {
         Castle.verifySdkConfigurationAndInitialize();
         RestApiFactory mockFactory = Mockito.mock(RestApiFactory.class);
         Castle sdk = Castle.sdk();
-        //When the utils are used to override the internal backend factory  
+        //When the utils are used to override the internal backend factory
         SdkMockUtil.modifyInternalBackendFactory(sdk, mockFactory);
         //Then the internal rest factory is mocked
         Assertions.assertThat(sdk.getInternalConfiguration().getRestApiFactory()).isSameAs(mockFactory);
     }
 
+    @Test
+    public void sdkOnConfigureLoadsDefault() throws CastleSdkConfigurationException {
 
+        // Given
+        Castle.initialize();
+
+        //When the sdk is initiated
+        Castle sdk = Castle.sdk();
+
+        //Then the configuration match the expected values from the class path properties
+        CastleConfiguration sdkConfiguration = sdk.getSdkConfiguration();
+        Assertions.assertThat(sdkConfiguration)
+                .extracting("apiSecret", "castleAppId")
+                .containsExactly("test_api_secret", "test_app_id");
+    }
+
+    @Test
+    public void sdkOnConfigureWithBuilder() throws CastleSdkConfigurationException {
+
+        // Given
+        Castle.initialize(
+            Castle.configurationBuilder()
+                .apiSecret("abcd")
+                .appId("1234")
+        );
+
+        //When the sdk is initiated
+        Castle sdk = Castle.sdk();
+
+        //Then the configuration match the expected values from the class path properties
+        CastleConfiguration sdkConfiguration = sdk.getSdkConfiguration();
+        Assertions.assertThat(sdkConfiguration)
+                .extracting("apiSecret", "castleAppId")
+                .containsExactly("abcd", "1234");
+    }
 }

--- a/src/test/java/io/castle/client/CastleTest.java
+++ b/src/test/java/io/castle/client/CastleTest.java
@@ -112,6 +112,7 @@ public class CastleTest {
             Castle.configurationBuilder()
                 .apiSecret("abcd")
                 .appId("1234")
+                .build()
         );
 
         //When the sdk is initiated

--- a/src/test/java/io/castle/client/internal/config/ConfigurationLoaderTest.java
+++ b/src/test/java/io/castle/client/internal/config/ConfigurationLoaderTest.java
@@ -78,7 +78,7 @@ public class ConfigurationLoaderTest {
     @Test
     public void loadFromEnv() throws CastleSdkConfigurationException {
         setEnvAndTestCorrectness(
-                "CASTLE_SDK_API_SECRET",
+                "CASTLE_API_SECRET",
                 "1234"
         );
         setEnvAndTestCorrectness(
@@ -128,6 +128,25 @@ public class ConfigurationLoaderTest {
                 .withAuthenticateFailoverStrategy(new AuthenticateFailoverStrategy(AuthenticateAction.DENY))
                 .build();
 
+        testLoad(expectedConfiguration);
+    }
+
+    @Test
+    public void loadLegacyApiSecretEnv() throws CastleSdkConfigurationException {
+        //given a property file not existing is provided
+        setEnvAndTestCorrectness("CASTLE_PROPERTIES_FILE", "notExistingFile.properties");
+        // and a minimal sdk configuration is provided in environment
+        setEnvAndTestCorrectness(
+                "CASTLE_SDK_API_SECRET",
+                "1234"
+        );
+        // and a expected config is the default configuration with the throw strategy
+        CastleConfiguration expectedConfiguration = CastleConfigurationBuilder
+                .defaultConfigBuilder()
+                .withApiSecret("1234")
+                .build();
+
+        // when then
         testLoad(expectedConfiguration);
     }
 


### PR DESCRIPTION
- Allow SDK to be configured programmatically using configuration builder
- Recommend using ENV or builder over properties file