### PR TITLE
Use helper from okhttp to generate credentials

### DIFF
--- a/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
+++ b/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
@@ -2,7 +2,11 @@ package io.castle.client.internal.backend;
 
 import io.castle.client.internal.config.CastleConfiguration;
 import io.castle.client.internal.json.CastleGsonModel;
-import okhttp3.*;
+import okhttp3.Credentials;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import okhttp3.logging.HttpLoggingInterceptor;
 
 import java.io.IOException;

--- a/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
+++ b/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
@@ -1,12 +1,8 @@
 package io.castle.client.internal.backend;
 
-import com.google.common.io.BaseEncoding;
 import io.castle.client.internal.config.CastleConfiguration;
 import io.castle.client.internal.json.CastleGsonModel;
-import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
 
 import java.io.IOException;
@@ -25,8 +21,7 @@ public class OkHttpFactory implements RestApiFactory {
     }
 
     private OkHttpClient createOkHttpClient() {
-        final String authString = ":" + configuration.getApiSecret();
-        final String authStringBase64 = "Basic " + BaseEncoding.base64().encode(authString.getBytes());
+        final String credential = Credentials.basic("", configuration.getApiSecret());
 
         OkHttpClient.Builder builder = new OkHttpClient()
                 .newBuilder()
@@ -46,7 +41,7 @@ public class OkHttpFactory implements RestApiFactory {
                     public Response intercept(Chain chain) throws IOException {
                         Request request = chain.request();
                         Request authenticatedRequest = request.newBuilder()
-                                .header("Authorization", authStringBase64).build();
+                                .header("Authorization", credential).build();
                         return chain.proceed(authenticatedRequest);
                     }
                 })

--- a/src/test/java/io/castle/client/CastleTrackHttpTest.java
+++ b/src/test/java/io/castle/client/CastleTrackHttpTest.java
@@ -24,6 +24,24 @@ public class CastleTrackHttpTest extends AbstractCastleHttpLayerTest {
     }
 
     @Test
+    public void trackEndpointHttpAuthorize() throws Exception {
+        // Given
+        Castle.verifySdkConfigurationAndInitialize();
+
+        server.enqueue(new MockResponse());
+
+        // And a mock Request
+        HttpServletRequest request = new MockHttpServletRequest();
+
+        // And an track request is made
+        sdk.onRequest(request).track("$login.successful", "1234");
+
+        // Then
+        RecordedRequest recordedRequest = server.takeRequest();
+        Assert.assertEquals("Basic OnRlc3RfYXBpX3NlY3JldA==", recordedRequest.getHeader("Authorization"));
+    }
+
+    @Test
     public void trackEndpointWithUserIDTest() throws InterruptedException {
         //given
         server.enqueue(new MockResponse());


### PR DESCRIPTION
Avoids usage of `BaseEncoding` module and uses built in helper from okhttp to generate Authorization header