### PR TITLE
Manual context

### DIFF
--- a/src/main/java/io/castle/client/Castle.java
+++ b/src/main/java/io/castle/client/Castle.java
@@ -6,6 +6,8 @@ import io.castle.client.internal.CastleApiImpl;
 import io.castle.client.internal.config.CastleConfiguration;
 import io.castle.client.internal.config.CastleConfigurationBuilder;
 import io.castle.client.internal.config.CastleSdkInternalConfiguration;
+import io.castle.client.internal.json.CastleGsonModel;
+import io.castle.client.internal.utils.CastleContextBuilder;
 import io.castle.client.model.CastleSdkConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +54,25 @@ public class Castle {
             throw new IllegalStateException("Castle SDK must be initialized. Call `Castle.initialize()` first");
         }
         return instance;
+    }
+
+    /**
+     * Creates a API client instance for sending a request
+     * @return A new instance of the API client {@code CastleApiImpl}
+     * @throws IllegalStateException when the SDK has not been properly initialized
+     */
+    public static CastleApi client() throws IllegalStateException {
+        return sdk().buildApiClient(false);
+    }
+
+    /**
+     * Creates a API client instance for sending a request
+     * @param doNotTrack when true, the API calls will be not realized and default values will be provided
+     * @return A new instance of the API client {@code CastleApiImpl}
+     * @throws IllegalStateException when the SDK has not been properly initialized
+     */
+    public static CastleApi client(boolean doNotTrack) throws IllegalStateException {
+        return sdk().buildApiClient(doNotTrack);
     }
 
     /**
@@ -106,6 +127,33 @@ public class Castle {
     }
 
     /**
+     * Returns a new builder object for constructing a CastleContext
+     * @return Return CatleContextBuilder object
+     */
+    public static CastleContextBuilder contextBuilder() {
+        return instance.buildContextBuilder();
+    }
+
+    /**
+     * Create a new instance of a request context builder
+     * @return a new instance of {@code CastleContextBuilder}
+     */
+    public CastleContextBuilder buildContextBuilder() {
+        return new CastleContextBuilder(
+            getSdkConfiguration(),
+            getGsonModel()
+        );
+    }
+
+    public CastleApi buildApiClient() {
+        return buildApiClient(false);
+    }
+
+    public CastleApi buildApiClient(boolean doNotTrack) {
+        return new CastleApiImpl(internalConfiguration, doNotTrack);
+    }
+
+    /**
      * Create a API context for the given request.
      * Tracking is ON by default.
      *
@@ -134,6 +182,14 @@ public class Castle {
      */
     public CastleConfiguration getSdkConfiguration() {
         return internalConfiguration.getConfiguration();
+    }
+
+    /**
+     * Get Gson model for serialization and deserialization
+     * @return the Gson model
+     */
+    public CastleGsonModel getGsonModel() {
+        return internalConfiguration.getModel();
     }
 
     /**

--- a/src/main/java/io/castle/client/internal/CastleApiImpl.java
+++ b/src/main/java/io/castle/client/internal/CastleApiImpl.java
@@ -233,14 +233,19 @@ public class CastleApiImpl implements CastleApi {
     }
 
     private JsonElement buildJson(CastleMessage message) throws CastleRuntimeException {
+        JsonObject contextJson;
         // Context can be either from the message or from the instance of this
         // class. Make sure we have one
+        CastleContext context = message.getContext();
+        if (context == null) {
+            contextJson = this.contextJson;
+        } else {
+            contextJson = configuration.getModel().getGson().toJsonTree(context).getAsJsonObject();
+        }
+
         JsonElement messageJson = configuration.getModel().getGson().toJsonTree(message);
         JsonObject messageObj = messageJson.getAsJsonObject();
-        JsonElement context = messageObj.get("context");
-        if (context == null) {
-            messageObj.add("context", contextJson);
-        }
+        messageObj.add("context", contextJson);
         return messageObj;
     }
 }

--- a/src/main/java/io/castle/client/model/CastleContext.java
+++ b/src/main/java/io/castle/client/model/CastleContext.java
@@ -21,7 +21,7 @@ public class CastleContext {
     private CastleOS os;
     private CastleScreen screen;
 
-    @SerializedName("userAgent")
+    @SerializedName("user_agent")
     private String userAgent;
 
     public boolean isActive() {

--- a/src/main/java/io/castle/client/model/CastleHeaders.java
+++ b/src/main/java/io/castle/client/model/CastleHeaders.java
@@ -1,5 +1,6 @@
 package io.castle.client.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CastleHeaders {
@@ -8,6 +9,10 @@ public class CastleHeaders {
 
     public List<CastleHeader> getHeaders() {
         return headers;
+    }
+
+    public static Builder builder() {
+        return new Builder(new CastleHeaders());
     }
 
     public void setHeaders(List<CastleHeader> headers) {
@@ -19,5 +24,29 @@ public class CastleHeaders {
         return "CastleHeaders{" +
                 "headers=" + headers +
                 '}';
+    }
+
+    public static class Builder {
+        private CastleHeaders headers;
+        private ArrayList<CastleHeader> headerList;
+
+        public Builder(CastleHeaders headers) {
+            this.headers = headers;
+            this.headerList = new ArrayList<>();
+        }
+
+        public CastleHeaders build() {
+            headers.setHeaders(headerList);
+            return headers;
+        }
+
+        public Builder add(String key, String value) {
+            this.headerList.add(new CastleHeader(key, value));
+            return self();
+        }
+
+        private Builder self() {
+            return this;
+        }
     }
 }

--- a/src/main/java/io/castle/client/model/CastleMessage.java
+++ b/src/main/java/io/castle/client/model/CastleMessage.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import javax.annotation.Nonnull;
 
 public class CastleMessage {
-    private CastleContext context;
+    private transient CastleContext context;
     private String createdAt;
     private String deviceToken;
     @Nonnull private String event;
@@ -116,6 +116,11 @@ public class CastleMessage {
 
         public CastleMessage build() {
             return payload;
+        }
+
+        public Builder context(CastleContext context) {
+            payload.setContext(context);
+            return self();
         }
 
         public Builder createdAt(String createdAt) {

--- a/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
+++ b/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
@@ -7,6 +7,7 @@ import io.castle.client.model.CastleContext;
 import io.castle.client.model.CastleHeader;
 import io.castle.client.model.CastleHeaders;
 import io.castle.client.model.CastleSdkConfigurationException;
+import io.castle.client.utils.SDKVersion;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -225,6 +226,24 @@ public class CastleContextBuilderTest {
 
         // Then
         Assertions.assertThat(context).isEqualToComparingFieldByFieldRecursively(standardContext);
+    }
+
+    @Test
+    public void withManualHeaders() throws CastleSdkConfigurationException {
+        // Given
+        CastleConfiguration configuration = CastleConfigurationBuilder
+            .defaultConfigBuilder()
+            .withApiSecret("abcd")
+            .build();
+        String contextJson = new CastleContextBuilder(configuration, model)
+            .headers(CastleHeaders.builder()
+                .add("User-Agent", "ua")
+                .build()
+            )
+            .toJson();
+
+        // Then
+        Assertions.assertThat(contextJson).isEqualTo("{\"active\":true,\"headers\":{\"User-Agent\":\"ua\"}," + SDKVersion.getLibraryString() + "}");
     }
 
     private String valueControlCache = "max-age=0";

--- a/src/test/java/io/castle/client/model/CastleContextTest.java
+++ b/src/test/java/io/castle/client/model/CastleContextTest.java
@@ -114,7 +114,7 @@ public class CastleContextTest {
                 "\"os\":{\"name\":\"o_name\",\"version\":\"0_version\"}," +
                 "\"screen\":{\"width\":10,\"height\":20,\"density\":2}," +
                 "\"timezone\":\"timezone\"," +
-                "\"userAgent\":\"userAgent\"}";
+                "\"user_agent\":\"userAgent\"}";
         JSONAssert.assertEquals(expectedJson, contextJson, true);
 
         // And json to object create the same structure


### PR DESCRIPTION
- Methods for getting an API client without a `request`
- Expose `context` method n CastleMessage builder
- Builder for CastleHeaders
- Send `user_agent` instead if `userAgent`
