### PR TITLE
Remove default whitelist

### DIFF
--- a/src/main/java/io/castle/client/internal/config/CastleConfigurationBuilder.java
+++ b/src/main/java/io/castle/client/internal/config/CastleConfigurationBuilder.java
@@ -119,37 +119,11 @@ public class CastleConfigurationBuilder {
 
     /**
      * Sets the default list of whitelisted headers.
-     * <p>
-     * The following are the default values:
-     * <ul>
-     * <li> {@code User-Agent}
-     * <li> {@code Accept-Language}
-     * <li> {@code Accept-Encoding}
-     * <li> {@code Accept-Charset}
-     * <li> {@code Accept}
-     * <li> {@code Accept-Datetime}
-     * <li> {@code X-Forwarded-For}
-     * <li> {@code Forwarded}
-     * <li> {@code X-Forwarded}
-     * <li> {@code X-Real-IP}
-     * <li> {@code REMOTE_ADDR}
-     * </ul>
      *
      * @return a castleConfigurationBuilder instance with the default list of whitelisted headers.
      */
     public CastleConfigurationBuilder withDefaultWhitelist() {
         this.whiteListHeaders = new LinkedList<>();
-        whiteListHeaders.add("User-Agent");
-        whiteListHeaders.add("Accept-Language");
-        whiteListHeaders.add("Accept-Encoding");
-        whiteListHeaders.add("Accept-Charset");
-        whiteListHeaders.add("Accept");
-        whiteListHeaders.add("Accept-Datetime");
-        whiteListHeaders.add("X-Forwarded-For");
-        whiteListHeaders.add("Forwarded");
-        whiteListHeaders.add("X-Forwarded");
-        whiteListHeaders.add("X-Real-IP");
-        whiteListHeaders.add("REMOTE_ADDR");
         return this;
     }
 

--- a/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
+++ b/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
@@ -113,8 +113,15 @@ public class CastleContextBuilder {
 
     private void addHeaderValue(ArrayList<CastleHeader> castleHeadersList, String key, String headerValue) {
         String keyNormalized = headerNormalizer.normalize(key);
-        if (!configuration.getBlackListHeaders().contains(keyNormalized)
-                && configuration.getWhiteListHeaders().contains(keyNormalized)) {
+        if (configuration.getBlackListHeaders().contains(keyNormalized)) {
+            // Do not add header since it is blacklisted
+            return;
+        }
+
+        // No whitelist set, everything is whitelisted
+        if (configuration.getWhiteListHeaders().isEmpty()) {
+            castleHeadersList.add(new CastleHeader(key, headerValue));
+        } else if (configuration.getWhiteListHeaders().contains(keyNormalized)) {
             castleHeadersList.add(new CastleHeader(key, headerValue));
         }
     }

--- a/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
+++ b/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
@@ -123,6 +123,9 @@ public class CastleContextBuilder {
             castleHeadersList.add(new CastleHeader(key, headerValue));
         } else if (configuration.getWhiteListHeaders().contains(keyNormalized)) {
             castleHeadersList.add(new CastleHeader(key, headerValue));
+        } else {
+            // Add scrubbed header
+            castleHeadersList.add(new CastleHeader(key, "true"));
         }
     }
 

--- a/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
+++ b/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
@@ -114,7 +114,8 @@ public class CastleContextBuilder {
     private void addHeaderValue(ArrayList<CastleHeader> castleHeadersList, String key, String headerValue) {
         String keyNormalized = headerNormalizer.normalize(key);
         if (configuration.getBlackListHeaders().contains(keyNormalized)) {
-            // Do not add header since it is blacklisted
+            // Scrub header since it is blacklisted
+            castleHeadersList.add(new CastleHeader(key, "true"));
             return;
         }
 

--- a/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
+++ b/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
@@ -63,6 +63,8 @@ public class CastleContextBuilderTest {
         for (CastleHeader header : standardContext.getHeaders().getHeaders()) {
             if (!header.getKey().equals("Cookie") && !header.getKey().equals(acceptLanguageHeader)) {
                 listOfHeaders.add(header);
+            } else {
+                listOfHeaders.add(new CastleHeader(header.getKey(), "true"));
             }
         }
         standardContext.getHeaders().setHeaders(listOfHeaders);
@@ -94,6 +96,8 @@ public class CastleContextBuilderTest {
         for (CastleHeader header : standardContext.getHeaders().getHeaders()) {
             if (!header.getKey().equals(connectionHeader)) {
                 listOfHeaders.add(header);
+            } else {
+                listOfHeaders.add(new CastleHeader(header.getKey(), "true"));
             }
         }
         standardContext.getHeaders().setHeaders(listOfHeaders);

--- a/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
+++ b/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
@@ -88,9 +88,14 @@ public class CastleContextBuilderTest {
         CastleContextBuilder builder = new CastleContextBuilder(configuration, model);
         HttpServletRequest standardRequest = getStandardRequestMock();
 
-        //And a expected castle context without any header
-        CastleContext standardContext = getStandardContext();
+        //And a expected castle context
+        CastleContext standardContext = getStandardScrubbedContext();
         List<CastleHeader> listOfHeaders = new ArrayList<>();
+        for (CastleHeader header : standardContext.getHeaders().getHeaders()) {
+            if (!header.getKey().equals(connectionHeader)) {
+                listOfHeaders.add(header);
+            }
+        }
         standardContext.getHeaders().setHeaders(listOfHeaders);
 
         //When
@@ -115,10 +120,12 @@ public class CastleContextBuilderTest {
         HttpServletRequest standardRequest = getStandardRequestMock();
 
         //And a expected castle context with a single whitelisted header
-        CastleContext standardContext = getStandardContext();
-        List<CastleHeader> listOfHeaders = new ArrayList<>();
-        listOfHeaders.add(new CastleHeader(connectionHeader, connection));
-        standardContext.getHeaders().setHeaders(listOfHeaders);
+        CastleContext standardContext = getStandardScrubbedContext();
+        for (CastleHeader header : standardContext.getHeaders().getHeaders()) {
+            if (header.getKey().equals(connectionHeader)) {
+                header.setValue(connection);
+            }
+        }
 
         //When
         CastleContext context = builder.fromHttpServletRequest(standardRequest).build();
@@ -312,6 +319,18 @@ public class CastleContextBuilderTest {
         expectedContext.setClientId(clientId);
         List<CastleHeader> listOfHeaders = expectedContext.getHeaders().getHeaders();
         listOfHeaders.add(listOfHeaders.size()-1, new CastleHeader(customClientIdHeader, clientId));
+        expectedContext.getHeaders().setHeaders(listOfHeaders);
+
+        return expectedContext;
+    }
+
+    public CastleContext getStandardScrubbedContext() {
+        CastleContext expectedContext = getStandardContext();
+
+        List<CastleHeader> listOfHeaders = expectedContext.getHeaders().getHeaders();
+        for (CastleHeader header : listOfHeaders) {
+            header.setValue("true");
+        }
         expectedContext.getHeaders().setHeaders(listOfHeaders);
 
         return expectedContext;

--- a/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
+++ b/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
@@ -60,10 +60,11 @@ public class CastleContextBuilderTest {
         //And a expected castle context without the accept-language header
         CastleContext standardContext = getStandardContext();
         List<CastleHeader> listOfHeaders = new ArrayList<>();
-        listOfHeaders.add(new CastleHeader(userAgentHeader, userAgent));
-        listOfHeaders.add(new CastleHeader(acceptHeader, accept));
-        listOfHeaders.add(new CastleHeader(acceptEncodingHeader, acceptEncoding));
-        listOfHeaders.add(new CastleHeader(cgiSpecHeaderName, ip));
+        for (CastleHeader header : standardContext.getHeaders().getHeaders()) {
+            if (!header.getKey().equals("Cookie") && !header.getKey().equals(acceptLanguageHeader)) {
+                listOfHeaders.add(header);
+            }
+        }
         standardContext.getHeaders().setHeaders(listOfHeaders);
 
         //When
@@ -145,10 +146,8 @@ public class CastleContextBuilderTest {
         //And a custom castle header
         standardRequest.addHeader(customClientIdHeader, "valueFromHeaders");
 
-
         //And a expected context value with matching clientId
-        CastleContext standardContext = getStandardContext();
-        standardContext.setClientId("valueFromHeaders");
+        CastleContext standardContext = getStandardContextWithClientId("valueFromHeaders");
 
         //When
         CastleContext context = builder.fromHttpServletRequest(standardRequest).build();
@@ -173,10 +172,8 @@ public class CastleContextBuilderTest {
         //And a custom castle header
         standardRequest.addHeader(customClientIdHeader, "valueFromHeaders");
 
-
         //And a expected context value with matching clientId
-        CastleContext standardContext = getStandardContext();
-        standardContext.setClientId("valueFromHeaders");
+        CastleContext standardContext = getStandardContextWithClientId("valueFromHeaders");
 
         //When
         CastleContext context = builder.fromHttpServletRequest(standardRequest).build();
@@ -284,16 +281,15 @@ public class CastleContextBuilderTest {
 
     private List<CastleHeader> getStandardHeaders() {
         List<CastleHeader> listOfHeaders = new ArrayList<>();
+        listOfHeaders.add(new CastleHeader(keyControlCache, valueControlCache));
         listOfHeaders.add(new CastleHeader(userAgentHeader, userAgent));
         listOfHeaders.add(new CastleHeader(acceptHeader, accept));
         listOfHeaders.add(new CastleHeader(acceptLanguageHeader, acceptLanguage));
         listOfHeaders.add(new CastleHeader(acceptEncodingHeader, acceptEncoding));
+        listOfHeaders.add(new CastleHeader(headerHost, hostValue));
+        listOfHeaders.add(new CastleHeader(refererHeader, referer));
+        listOfHeaders.add(new CastleHeader(connectionHeader, connection));
         listOfHeaders.add(new CastleHeader(cgiSpecHeaderName, ip));
-//        listOfHeaders.add(new CastleHeader(keyControlCache, valueControlCache));
-//        listOfHeaders.add(new CastleHeader(customClientIdHeader, clientId));
-//        listOfHeaders.add(new CastleHeader(headerHost, hostValue));
-//        listOfHeaders.add(new CastleHeader(refererHeader, referer));
-//        listOfHeaders.add(new CastleHeader(connectionHeader, connection));
         return listOfHeaders;
     }
 
@@ -311,4 +307,13 @@ public class CastleContextBuilderTest {
         return expectedContext;
     }
 
+    public CastleContext getStandardContextWithClientId(String clientId) {
+        CastleContext expectedContext = getStandardContext();
+        expectedContext.setClientId(clientId);
+        List<CastleHeader> listOfHeaders = expectedContext.getHeaders().getHeaders();
+        listOfHeaders.add(listOfHeaders.size()-1, new CastleHeader(customClientIdHeader, clientId));
+        expectedContext.getHeaders().setHeaders(listOfHeaders);
+
+        return expectedContext;
+    }
 }

--- a/src/test/java/io/castle/client/model/CastleConfigurationBuilderTest.java
+++ b/src/test/java/io/castle/client/model/CastleConfigurationBuilderTest.java
@@ -21,18 +21,7 @@ public class CastleConfigurationBuilderTest {
         Assertions.assertThat(config.getApiSecret()).isEqualTo(apiSecret);
         Assertions.assertThat(config.getCastleAppId()).isEqualTo(castleAppId);
         Assertions.assertThat(config.getBlackListHeaders()).contains("cookie");
-        Assertions.assertThat(config.getWhiteListHeaders()).contains(
-                "user-agent",
-                "accept-language",
-                "accept-encoding",
-                "accept-charset",
-                "accept",
-                "accept-datetime",
-                "x-forwarded-for",
-                "forwarded",
-                "x-forwarded",
-                "x-real-ip",
-                "remote-addr");
+        Assertions.assertThat(config.getWhiteListHeaders()).isEmpty();
         Assertions.assertThat(config.getAuthenticateFailoverStrategy().getDefaultAction()).isEqualTo(AuthenticateAction.ALLOW);
         Assertions.assertThat(config.getTimeout()).isEqualTo(500);
 


### PR DESCRIPTION
Remove default whitelist, default is now to add all headers. If a non-empty whitelist is set only whitelisted headers are added.