### PR TITLE
#38 Add `deviceToken` to Verdict class to match the response returned…

### DIFF
--- a/src/main/java/io/castle/client/internal/utils/VerdictBuilder.java
+++ b/src/main/java/io/castle/client/internal/utils/VerdictBuilder.java
@@ -8,6 +8,7 @@ public class VerdictBuilder {
     private String userId;
     private boolean failover;
     private String failoverReason;
+    private String deviceToken;
 
     private VerdictBuilder() {
     }
@@ -33,12 +34,18 @@ public class VerdictBuilder {
         return this;
     }
 
+    public VerdictBuilder withDeviceToken(final String deviceToken) {
+        this.deviceToken = deviceToken;
+        return this;
+    }
+
     public Verdict build() {
         Verdict verdict = new Verdict();
         verdict.setAction(action);
         verdict.setUserId(userId);
         verdict.setFailover(failover);
         verdict.setFailoverReason(failoverReason);
+        verdict.setDeviceToken(deviceToken);
         return verdict;
     }
 
@@ -55,8 +62,9 @@ public class VerdictBuilder {
 
     public static Verdict fromTransport(VerdictTransportModel transport) {
         return success()
-                .withAction(transport.getAction())
-                .withUserId(transport.getUserId())
-                .build();
+            .withAction(transport.getAction())
+            .withUserId(transport.getUserId())
+            .withDeviceToken(transport.getDeviceToken())
+            .build();
     }
 }

--- a/src/main/java/io/castle/client/internal/utils/VerdictTransportModel.java
+++ b/src/main/java/io/castle/client/internal/utils/VerdictTransportModel.java
@@ -6,6 +6,7 @@ public class VerdictTransportModel {
 
     private AuthenticateAction action;
     private String userId;
+    private String deviceToken;
 
     public AuthenticateAction getAction() {
         return action;
@@ -21,5 +22,13 @@ public class VerdictTransportModel {
 
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    public String getDeviceToken() {
+        return deviceToken;
+    }
+
+    public void setDeviceToken(String deviceToken) {
+        this.deviceToken = deviceToken;
     }
 }

--- a/src/main/java/io/castle/client/model/Verdict.java
+++ b/src/main/java/io/castle/client/model/Verdict.java
@@ -25,6 +25,11 @@ public class Verdict {
      */
     private String failoverReason;
 
+    /**
+     * String representing a device ID associated with an authenticate call.
+     */
+    private String deviceToken;
+
     public AuthenticateAction getAction() {
         return action;
     }
@@ -55,5 +60,13 @@ public class Verdict {
 
     public void setFailoverReason(String failoverReason) {
         this.failoverReason = failoverReason;
+    }
+
+    public String getDeviceToken() {
+        return deviceToken;
+    }
+
+    public void setDeviceToken(String deviceToken) {
+        this.deviceToken = deviceToken;
     }
 }

--- a/src/test/java/io/castle/client/CastleAuthenticateHttpTest.java
+++ b/src/test/java/io/castle/client/CastleAuthenticateHttpTest.java
@@ -22,7 +22,8 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
 
     private static final String DENY_RESPONSE = "{\n" +
                                                 "  \"action\": \"deny\",\n" +
-                                                "  \"user_id\": \"12345\"\n" +
+                                                "  \"user_id\": \"12345\",\n" +
+                                                "  \"device_token\": \"abcdefg1234\"\n" +
                                                 "}";
 
     public CastleAuthenticateHttpTest() {
@@ -96,6 +97,7 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
         server.enqueue(new MockResponse().setBody(DENY_RESPONSE));
         String id = "12345";
         String event = "$login.succeeded";
+        String deviceToken = "abcdefg1234";
 
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
@@ -123,6 +125,7 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
         Verdict expected = VerdictBuilder.success()
                 .withAction(AuthenticateAction.DENY)
                 .withUserId("12345")
+                .withDeviceToken(deviceToken)
                 .build();
         waitForValueAndVerify(result, expected);
     }
@@ -133,6 +136,7 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
         server.enqueue(new MockResponse().setBody(DENY_RESPONSE));
         String id = "12345";
         String event = "$login.succeeded";
+        String deviceToken = "abcdefg1234";
 
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
@@ -164,6 +168,7 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
         Verdict expected = VerdictBuilder.success()
                 .withAction(AuthenticateAction.DENY)
                 .withUserId("12345")
+                .withDeviceToken(deviceToken)
                 .build();
         waitForValueAndVerify(result, expected);
     }
@@ -259,6 +264,7 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
         server.enqueue(new MockResponse().setBody(DENY_RESPONSE));
         String id = "12345";
         String event = "$login.succeeded";
+        String deviceToken = "abcdefg1234";
 
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
@@ -270,6 +276,7 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
         Verdict expected = VerdictBuilder.success()
                 .withAction(AuthenticateAction.DENY)
                 .withUserId(id)
+                .withDeviceToken(deviceToken)
                 .build();
         Assertions.assertThat(verdict).isEqualToComparingFieldByField(expected);
 
@@ -285,6 +292,7 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
         server.enqueue(new MockResponse().setBody(DENY_RESPONSE));
         String id = "12345";
         String event = "$login.succeeded";
+        String deviceToken = "abcdefg1234";
 
         // And a mock Request
         HttpServletRequest request = new MockHttpServletRequest();
@@ -302,6 +310,7 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
         Verdict expected = VerdictBuilder.success()
                 .withAction(AuthenticateAction.DENY)
                 .withUserId(id)
+                .withDeviceToken(deviceToken)
                 .build();
         Assertions.assertThat(verdict).isEqualToComparingFieldByField(expected);
 


### PR DESCRIPTION
… by the /authenticate endpoint