### PR TITLE
Add support for configuring a list of ip headers

### DIFF
--- a/src/main/java/io/castle/client/internal/config/CastleConfiguration.java
+++ b/src/main/java/io/castle/client/internal/config/CastleConfiguration.java
@@ -59,7 +59,9 @@ public class CastleConfiguration {
      */
     private final boolean logHttpRequests;
 
-    public CastleConfiguration(String apiBaseUrl, int timeout, AuthenticateFailoverStrategy authenticateFailoverStrategy, List<String> whiteListHeaders, List<String> blackListHeaders, String apiSecret, String castleAppId, CastleBackendProvider backendProvider, boolean logHttpRequests) {
+    private final List<String> ipHeaders;
+
+    public CastleConfiguration(String apiBaseUrl, int timeout, AuthenticateFailoverStrategy authenticateFailoverStrategy, List<String> whiteListHeaders, List<String> blackListHeaders, String apiSecret, String castleAppId, CastleBackendProvider backendProvider, boolean logHttpRequests, List<String> ipHeaders) {
         this.apiBaseUrl = apiBaseUrl;
         this.timeout = timeout;
         this.authenticateFailoverStrategy = authenticateFailoverStrategy;
@@ -69,6 +71,7 @@ public class CastleConfiguration {
         this.castleAppId = castleAppId;
         this.backendProvider = backendProvider;
         this.logHttpRequests = logHttpRequests;
+        this.ipHeaders = ipHeaders;
     }
 
     public String getApiBaseUrl() {
@@ -115,5 +118,9 @@ public class CastleConfiguration {
 
     public boolean isLogHttpRequests() {
         return logHttpRequests;
+    }
+
+    public List<String> getIpHeaders() {
+        return ipHeaders;
     }
 }

--- a/src/main/java/io/castle/client/internal/config/CastleConfigurationBuilder.java
+++ b/src/main/java/io/castle/client/internal/config/CastleConfigurationBuilder.java
@@ -82,6 +82,11 @@ public class CastleConfigurationBuilder {
      */
     private boolean logHttpRequests = false;
 
+    /**
+     * Sorted list of headers to use for IP value in context
+     */
+    private List<String> ipHeaders;
+
     private CastleConfigurationBuilder() {
     }
 
@@ -329,14 +334,16 @@ public class CastleConfigurationBuilder {
             throw new CastleSdkConfigurationException(Joiner.on(System.lineSeparator()).join(errorMessages));
         }
         HeaderNormalizer normalizer = new HeaderNormalizer();
-        return new CastleConfiguration(apiBaseUrl, timeout,
+        return new CastleConfiguration(apiBaseUrl,
+                timeout,
                 failoverStrategy,
                 normalizer.normalizeList(whiteListHeaders),
                 normalizer.normalizeList(blackListHeaders),
                 apiSecret,
                 castleAppId,
                 backendProvider,
-                logHttpRequests);
+                logHttpRequests,
+                ipHeaders);
     }
 
     /**
@@ -390,5 +397,21 @@ public class CastleConfigurationBuilder {
     /* alias for logHttpRequests */
     public CastleConfigurationBuilder enableHttpLogging(Boolean logHttpRequests) {
         return withLogHttpRequests(logHttpRequests);
+    }
+
+    /**
+     * Sorted list of headers to use when extracting IP from headers.
+     *
+     * @param ipHeaders sorted list of headers.
+     * @return a castleConfigurationBuilder with IP headers set
+     */
+    public CastleConfigurationBuilder withIPHeaders(List<String> ipHeaders) {
+        this.ipHeaders = ipHeaders;
+        return this;
+    }
+
+    /* alias for withIPHeaders */
+    public CastleConfigurationBuilder ipHeaders(List<String> ipHeaders) {
+        return withIPHeaders(ipHeaders);
     }
 }

--- a/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
+++ b/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
@@ -75,7 +75,16 @@ public class CastleContextBuilder {
         context.setClientId(setClientIdFromHttpServletRequest(request));
         this.headers = setCastleHeadersFromHttpServletRequest(request);
         context.setUserAgent(request.getHeader("User-Agent"));
+
         context.setIp(request.getRemoteAddr());
+        if (configuration.getIpHeaders() != null) {
+            for (String header : configuration.getIpHeaders()) {
+                if (request.getHeader(header) != null) {
+                    context.setIp(request.getHeader(header));
+                    break;
+                }
+            }
+        }
         return this;
     }
 

--- a/src/test/java/io/castle/client/CastleTest.java
+++ b/src/test/java/io/castle/client/CastleTest.java
@@ -119,7 +119,7 @@ public class CastleTest {
     @Test
     public void sdkOnConfigureWithSecretOnly() throws CastleSdkConfigurationException {
         // When the SDK is initiated
-        Castle sdk =Castle.initialize("abcd");
+        Castle sdk = Castle.initialize("abcd");
 
         //Then the configuration match the expected values from the initialization
         CastleConfiguration sdkConfiguration = sdk.getSdkConfiguration();

--- a/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
+++ b/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
@@ -292,11 +292,11 @@ public class CastleContextBuilderTest {
                 .build();
 
         MockHttpServletRequest standardRequest = getStandardRequestMock();
-        standardRequest.addHeader("X-Forwarded-For", "1.1.1.1");
-        standardRequest.addHeader("CF-Connecting-IP", "2.2.2.2");
+        standardRequest.addHeader("X-Forwarded-For", "1.1.1.1,2.2.2.2,3.3.3.3");
+        standardRequest.addHeader("CF-Connecting-IP", "4.4.4.4");
 
         CastleContext standardContext = getStandardContext();
-        standardContext.setIp("1.1.1.1");
+        standardContext.setIp("1.1.1.1,2.2.2.2,3.3.3.3");
 
         CastleContext context = new CastleContextBuilder(configuration, model)
                 .fromHttpServletRequest(standardRequest)

--- a/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
+++ b/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
@@ -17,6 +17,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 
@@ -245,6 +246,29 @@ public class CastleContextBuilderTest {
 
         // Then
         JSONAssert.assertEquals(contextJson, "{\"active\":true,\"headers\":{\"User-Agent\":\"ua\"}," + SDKVersion.getLibraryString() + "}", false);
+    }
+
+    @Test
+    public void withCustomIPHeaders() throws CastleSdkConfigurationException, JSONException {
+        // Given
+        CastleConfiguration configuration = CastleConfigurationBuilder.defaultConfigBuilder()
+                .apiSecret("abcd")
+                .ipHeaders(Arrays.asList("X-Forwarded-For", "CF-Connecting-IP"))
+                .build();
+
+        MockHttpServletRequest standardRequest = getStandardRequestMock();
+        standardRequest.addHeader("X-Forwarded-For", "1.1.1.1");
+        standardRequest.addHeader("CF-Connecting-IP", "2.2.2.2");
+
+        CastleContext standardContext = getStandardContext();
+        standardContext.setIp("1.1.1.1");
+
+        CastleContext context = new CastleContextBuilder(configuration, model)
+                .fromHttpServletRequest(standardRequest)
+                .build();
+
+        //Then
+        Assertions.assertThat(context.getIp()).isEqualTo(standardContext.getIp());
     }
 
     private String valueControlCache = "max-age=0";


### PR DESCRIPTION
Support configuring castle with a sorted list of headers to use for getting the true IP. Will go through the list to until one header is found. If no headers are found the SDK will fall back to `REMOTE_ADDR`.