### PR TITLE
Correct default values when building context from request

### DIFF
--- a/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
+++ b/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
@@ -74,7 +74,7 @@ public class CastleContextBuilder {
     public CastleContextBuilder fromHttpServletRequest(HttpServletRequest request) {
         context.setClientId(setClientIdFromHttpServletRequest(request));
         this.headers = setCastleHeadersFromHttpServletRequest(request);
-        context.setUserAgent(request.getHeader("User-Agent"));
+        context.setUserAgent(setUserAgentFromHttpServletRequest(request));
 
         context.setIp(request.getRemoteAddr());
         if (configuration.getIpHeaders() != null) {
@@ -141,11 +141,11 @@ public class CastleContextBuilder {
 
     /**
      * Extract the clientId from the request.
-     * If header 'X-Castle-Client-Id' is set use that value, if not use __cid cookie, if not use empty string ''
+     * If header 'X-Castle-Client-Id' is set use that value, if not use __cid cookie, if none is set default to false
      * @param request HttpServletRequest to extract clientId from
-     * @return a string clientId
+     * @return a string clientId or false
      */
-    private String setClientIdFromHttpServletRequest(HttpServletRequest request) {
+    private Object setClientIdFromHttpServletRequest(HttpServletRequest request) {
         String cid = request.getHeader("X-Castle-Client-Id");
 
         // If client id header is not included, check cookie
@@ -160,7 +160,29 @@ public class CastleContextBuilder {
             }
         }
 
+        // If cid could not be extracted, default to false
+        if (cid == null) {
+            return false;
+        }
+
         return cid;
+    }
+
+    /**
+     * Extract the User Agent from the request.
+     * If header 'User-Agent' is set use that value, if not default to false
+     * @param request HttpServletRequest to extract User Agent from
+     * @return a string User Agent or false
+     */
+    private Object setUserAgentFromHttpServletRequest(HttpServletRequest request) {
+        String userAgent = request.getHeader("User-Agent");
+
+        // If User Agent header is not present, default to false
+        if (userAgent == null) {
+            return false;
+        }
+
+        return userAgent;
     }
 
 }

--- a/src/main/java/io/castle/client/model/CastleContext.java
+++ b/src/main/java/io/castle/client/model/CastleContext.java
@@ -48,6 +48,14 @@ public class CastleContext {
         this.clientId = clientId;
     }
 
+    public void setClientId(Object clientId) {
+        if (clientId instanceof Boolean || clientId instanceof String) {
+            this.clientId = clientId;
+        } else {
+            throw new IllegalArgumentException("ClientId must be a string or boolean value");
+        }
+    }
+
     public void setClientId(boolean clientId) {
         this.clientId = clientId;
     }
@@ -138,6 +146,14 @@ public class CastleContext {
 
     public Object getUserAgent() {
         return userAgent;
+    }
+
+    public void setUserAgent(Object userAgent) {
+        if (userAgent instanceof Boolean || userAgent instanceof String) {
+            this.userAgent = userAgent;
+        } else {
+            throw new IllegalArgumentException("User Agent must be a string or boolean value");
+        }
     }
 
     public void setUserAgent(String userAgent) {

--- a/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
+++ b/src/test/java/io/castle/client/internal/utils/CastleContextBuilderTest.java
@@ -33,7 +33,7 @@ public class CastleContextBuilderTest {
                 .build();
         CastleContextBuilder builder = new CastleContextBuilder(configuration, model);
         HttpServletRequest standardRequest = getStandardRequestMock();
-        CastleContext standardContext = getStandardContext();
+        CastleContext standardContext = getStandardContextFromServletRequest();
 
         //When
         CastleContext context = builder.fromHttpServletRequest(standardRequest)
@@ -59,7 +59,7 @@ public class CastleContextBuilderTest {
         HttpServletRequest standardRequest = getStandardRequestMock();
 
         //And a expected castle context without the accept-language header
-        CastleContext standardContext = getStandardContext();
+        CastleContext standardContext = getStandardContextFromServletRequest();
         List<CastleHeader> listOfHeaders = new ArrayList<>();
         for (CastleHeader header : standardContext.getHeaders().getHeaders()) {
             if (!header.getKey().equals("Cookie") && !header.getKey().equals(acceptLanguageHeader)) {
@@ -216,6 +216,7 @@ public class CastleContextBuilderTest {
             .ip(ip)
             .device(getStandardDevice())
             .build();
+
         // And
         CastleContext standardContext = getStandardContext();
 
@@ -227,7 +228,7 @@ public class CastleContextBuilderTest {
     public void toAndFromJson() throws CastleSdkConfigurationException {
         // Given
         MockHttpServletRequest standardRequest = getStandardRequestMock();
-        CastleContext standardContext = getStandardContext();
+        CastleContext standardContext = getStandardContextFromServletRequest();
         CastleConfiguration configuration = CastleConfigurationBuilder
             .defaultConfigBuilder()
             .withApiSecret("abcd")
@@ -263,7 +264,7 @@ public class CastleContextBuilderTest {
             .toJson();
 
         // Then
-        JSONAssert.assertEquals(contextJson, "{\"active\":true,\"device\":{\"id\":\"d_id\",\"manufacturer\":\"d_manufacturer\",\"model\":\"d_model\",\"name\":\"d_name\",\"type\":\"d_type\"},\"headers\":{\"User-Agent\":\"ua\"}," + SDKVersion.getLibraryString() + "}", false);
+        JSONAssert.assertEquals(contextJson, "{\"active\":true,\"client_id\":false,\"user_agent\":\"ua\",\"device\":{\"id\":\"d_id\",\"manufacturer\":\"d_manufacturer\",\"model\":\"d_model\",\"name\":\"d_name\",\"type\":\"d_type\"},\"headers\":{\"User-Agent\":\"ua\"}," + SDKVersion.getLibraryString() + "}", false);
     }
 
     @Test
@@ -382,6 +383,13 @@ public class CastleContextBuilderTest {
         return device;
     }
 
+    public CastleContext getStandardContextFromServletRequest() {
+        CastleContext expectedContext = getStandardContext();
+        expectedContext.setClientId(false);
+
+        return expectedContext;
+    }
+
     public CastleContext getStandardContextWithClientId(String clientId) {
         CastleContext expectedContext = getStandardContext();
         expectedContext.setClientId(clientId);
@@ -393,7 +401,7 @@ public class CastleContextBuilderTest {
     }
 
     public CastleContext getStandardScrubbedContext() {
-        CastleContext expectedContext = getStandardContext();
+        CastleContext expectedContext = getStandardContextFromServletRequest();
 
         List<CastleHeader> listOfHeaders = expectedContext.getHeaders().getHeaders();
         for (CastleHeader header : listOfHeaders) {


### PR DESCRIPTION
Default to `false` when building context from and user agent or client id was not present in the request. 