### PR TITLE
Add a missing equals and hashCode methods to some model classes

### DIFF
--- a/src/main/java/io/castle/client/model/CastleHeader.java
+++ b/src/main/java/io/castle/client/model/CastleHeader.java
@@ -1,5 +1,7 @@
 package io.castle.client.model;
 
+import java.util.Objects;
+
 public class CastleHeader {
     private String key;
     private String value;
@@ -26,6 +28,20 @@ public class CastleHeader {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CastleHeader that = (CastleHeader) o;
+        return Objects.equals(key, that.key) &&
+                Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
     }
 
     @Override

--- a/src/main/java/io/castle/client/model/CastleHeaders.java
+++ b/src/main/java/io/castle/client/model/CastleHeaders.java
@@ -2,6 +2,7 @@ package io.castle.client.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class CastleHeaders {
 
@@ -17,6 +18,19 @@ public class CastleHeaders {
 
     public void setHeaders(List<CastleHeader> headers) {
         this.headers = headers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CastleHeaders that = (CastleHeaders) o;
+        return Objects.equals(headers, that.headers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(headers);
     }
 
     @Override

--- a/src/main/java/io/castle/client/model/CastleSdkRef.java
+++ b/src/main/java/io/castle/client/model/CastleSdkRef.java
@@ -31,21 +31,6 @@ public class CastleSdkRef {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CastleSdkRef that = (CastleSdkRef) o;
-        return Objects.equals(name, that.name) &&
-                Objects.equals(version, that.version);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, version);
-    }
-
-
-    @Override
     public String toString() {
         return "CastleSdkRef{" +
                 "name='" + name + '\'' +
@@ -53,6 +38,23 @@ public class CastleSdkRef {
                 ", platform='" + platform + '\'' +
                 ", platformVersion='" + platformVersion + '\'' +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CastleSdkRef that = (CastleSdkRef) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(version, that.version) &&
+                Objects.equals(platform, that.platform) &&
+                Objects.equals(platformVersion, that.platformVersion);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(name, version, platform, platformVersion);
     }
 
     private Properties loadSdkVersion() {

--- a/src/main/java/io/castle/client/model/CastleSdkRef.java
+++ b/src/main/java/io/castle/client/model/CastleSdkRef.java
@@ -1,5 +1,6 @@
 package io.castle.client.model;
 
+import java.util.Objects;
 import java.util.Properties;
 import io.castle.client.Castle;
 import io.castle.client.internal.config.PropertiesReader;
@@ -28,6 +29,21 @@ public class CastleSdkRef {
     public String getVersion() {
         return version;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CastleSdkRef that = (CastleSdkRef) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, version);
+    }
+
 
     @Override
     public String toString() {


### PR DESCRIPTION
We've found it useful to rely on `equals` for these classes when we're writing tests against the SDK. This PR uses the utility methods on `Objects` to implement `equals` and `hashCode`.