### PR TITLE
Fix verdict response validation

### DIFF
--- a/src/main/java/io/castle/client/internal/backend/OkRestApiBackend.java
+++ b/src/main/java/io/castle/client/internal/backend/OkRestApiBackend.java
@@ -148,7 +148,7 @@ public class OkRestApiBackend implements RestApi {
             Gson gson = model.getGson();
             JsonParser jsonParser = model.getJsonParser();
             VerdictTransportModel transport = gson.fromJson(jsonResponse, VerdictTransportModel.class);
-            if (transport != null && transport.getAction() != null && transport.getUserId() != null) {
+            if (transport != null && transport.getAction() != null) {
                 return VerdictBuilder.fromTransport(transport, jsonParser.parse(jsonResponse));
             } else {
                 errorReason = "Invalid JSON in response";

--- a/src/test/java/io/castle/client/CastleAuthenticateHttpTest.java
+++ b/src/test/java/io/castle/client/CastleAuthenticateHttpTest.java
@@ -415,9 +415,9 @@ public class CastleAuthenticateHttpTest extends AbstractCastleHttpLayerTest {
 
     }
     @Test(expected = CastleRuntimeException.class)
-    public void authenticationUseDefaultOnBadResponseFormatTestMissingUseCase() throws InterruptedException {
+    public void authenticationUseDefaultOnBadResponseFormatTestInvalidActionUseCase() throws InterruptedException {
         //given a response do not match the transport contract
-        testIlegalJsonForAuthenticate("{\"action\":\"deny\"}");
+        testIlegalJsonForAuthenticate("{\"action\":\"action\"}");
 
     }
 


### PR DESCRIPTION
Remove non null check for returned verdict since a response where userId is null or not present is valid.