### PR TITLE
Fix compilation error with okhttp 3.4.1

### DIFF
--- a/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
+++ b/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
@@ -47,7 +47,7 @@ public class OkHttpFactory implements RestApiFactory {
                         return chain.proceed(authenticatedRequest);
                     }
                 })
-                .connectionSpecs(ImmutableList.of(ConnectionSpec.MODERN_TLS, ConnectionSpec.CLEARTEXT))
+                .connectionSpecs(ImmutableList.of(ConnectionSpec.COMPATIBLE_TLS, ConnectionSpec.CLEARTEXT))
                 .build();
 
         return client;

--- a/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
+++ b/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
@@ -37,13 +37,6 @@ public class OkHttpFactory implements RestApiFactory {
             builder = builder.addInterceptor(logging);
         }
 
-        ConnectionSpec sslSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                .tlsVersions(TlsVersion.TLS_1_1, TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
-                .build();
-
-        ConnectionSpec cleartextSpec = new ConnectionSpec.Builder(ConnectionSpec.CLEARTEXT)
-                .build();
-
         OkHttpClient client = builder
                 .addInterceptor(new Interceptor() {
                     @Override
@@ -54,7 +47,7 @@ public class OkHttpFactory implements RestApiFactory {
                         return chain.proceed(authenticatedRequest);
                     }
                 })
-                .connectionSpecs(ImmutableList.of(sslSpec, cleartextSpec))
+                .connectionSpecs(ImmutableList.of(ConnectionSpec.MODERN_TLS, ConnectionSpec.CLEARTEXT))
                 .build();
 
         return client;


### PR DESCRIPTION
Should fix: https://github.com/castle/castle-java/issues/79

Adding configuration in a more orthodox fashion ([an example from another repo](https://github.com/mapbox/mapbox-events-android/blob/master/libtelemetry/src/main/java/com/mapbox/android/telemetry/TelemetryClientSettings.java#L160)).

Used [COMPATIBLE_TLS](https://github.com/square/okhttp/blob/parent-3.13.1/okhttp/src/main/java/okhttp3/ConnectionSpec.java#L121) so we don't break consumers who currently use `TLSv1.1`.

Not sure if there was some motivation behind explicitly defining `TLSv1.1` as opposed to just using `ConnectionSpec.MODERN_TLS`, or if for some reason we don't want to support `TLSv1.0`.