### PR TITLE
Additional CastleHeaders for more convenient initialization

### DIFF
--- a/src/main/java/io/castle/client/model/CastleHeaders.java
+++ b/src/main/java/io/castle/client/model/CastleHeaders.java
@@ -20,6 +20,10 @@ public class CastleHeaders {
         this.headers = headers;
     }
 
+    public CastleHeaders(List<CastleHeader> headers) { this.headers = headers; }
+
+    public CastleHeaders() {}
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
IIUC if you have `List<CastleHeader>` and you want to transform this into `CastleHeaders` you must do:
```
List<CastleHeader> castleHeaderList = createListSomehow(...)
CastlehHeaders castleHeaders = new CastleHeaders()
castleHeaders.set(castleHeaderList)
```
It would be more convenient to be able to do:
```
List<CastleHeader> castleHeaderList = createListSomehow(...)
CastlehHeaders castleHeaders = new CastleHeaders(castleHeaderList)
```