### PR TITLE
Fixed 13 flaky tests

### DIFF
--- a/src/test/java/io/castle/client/model/CastleContextTest.java
+++ b/src/test/java/io/castle/client/model/CastleContextTest.java
@@ -1,6 +1,8 @@
 package io.castle.client.model;
 
 import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import io.castle.client.internal.json.CastleGsonModel;
 import io.castle.client.utils.SDKVersion;
 import org.assertj.core.api.Assertions;
@@ -24,10 +26,17 @@ public class CastleContextTest {
 
         //when
         String contextJson = model.getGson().toJson(aContext);
+        JsonObject convertedObject = new Gson().fromJson(contextJson, JsonObject.class);
+        JsonObject libraryObject = new Gson().fromJson(convertedObject.get("library").toString(), JsonObject.class);
 
         //Then
-        Assertions.assertThat(contextJson).isEqualTo("{\"active\":true," + SDKVersion.getLibraryString() +"}");
-
+        System.out.println("\"library\":" + convertedObject.get("library").toString());
+        System.out.println(SDKVersion.getLibraryString());
+        Assertions.assertThat(convertedObject.get("active").getAsString()).isEqualTo("true");
+        Assertions.assertThat(libraryObject.get("name").getAsString()).isEqualTo("castle-java");
+        Assertions.assertThat(libraryObject.get("version").getAsString()).isEqualTo("2.0.0");
+        Assertions.assertThat(libraryObject.get("platform").getAsString()).isEqualTo("OpenJDK 64-Bit Server VM");
+        Assertions.assertThat(libraryObject.get("platform_version").getAsString()).isEqualTo("25.292-b10");
     }
 
     @Test

--- a/src/test/java/io/castle/client/model/CastleContextTest.java
+++ b/src/test/java/io/castle/client/model/CastleContextTest.java
@@ -1,8 +1,7 @@
 package io.castle.client.model;
 
 import com.google.common.collect.ImmutableList;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import io.castle.client.utils.SDKVersion;
 import org.assertj.core.api.Assertions;
@@ -26,17 +25,11 @@ public class CastleContextTest {
 
         //when
         String contextJson = model.getGson().toJson(aContext);
-        JsonObject convertedObject = new Gson().fromJson(contextJson, JsonObject.class);
-        JsonObject libraryObject = new Gson().fromJson(convertedObject.get("library").toString(), JsonObject.class);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"active\":true," + SDKVersion.getLibraryString() +"}";
 
         //Then
-        System.out.println("\"library\":" + convertedObject.get("library").toString());
-        System.out.println(SDKVersion.getLibraryString());
-        Assertions.assertThat(convertedObject.get("active").getAsString()).isEqualTo("true");
-        Assertions.assertThat(libraryObject.get("name").getAsString()).isEqualTo("castle-java");
-        Assertions.assertThat(libraryObject.get("version").getAsString()).isEqualTo("2.0.0");
-        Assertions.assertThat(libraryObject.get("platform").getAsString()).isEqualTo("OpenJDK 64-Bit Server VM");
-        Assertions.assertThat(libraryObject.get("platform_version").getAsString()).isEqualTo("25.292-b10");
+        Assertions.assertThat(parser.parse(contextJson)).isEqualTo(parser.parse(expected));
     }
 
     @Test

--- a/src/test/java/io/castle/client/model/CastleDeviceTest.java
+++ b/src/test/java/io/castle/client/model/CastleDeviceTest.java
@@ -1,8 +1,7 @@
 package io.castle.client.model;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -23,14 +22,11 @@ public class CastleDeviceTest {
 
         // When
         String payloadJson = model.getGson().toJson(device);
-        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"id\":\"d_id\",\"manufacturer\":\"d_manufacturer\",\"model\":\"d_model\",\"name\":\"d_name\",\"type\":\"d_type\"}";
 
         // Then
-        Assertions.assertThat(convertedObject.get("id").getAsString()).isEqualTo("d_id");
-        Assertions.assertThat(convertedObject.get("manufacturer").getAsString()).isEqualTo("d_manufacturer");
-        Assertions.assertThat(convertedObject.get("model").getAsString()).isEqualTo("d_model");
-        Assertions.assertThat(convertedObject.get("name").getAsString()).isEqualTo("d_name");
-        Assertions.assertThat(convertedObject.get("type").getAsString()).isEqualTo("d_type");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
     }
 
     @Test
@@ -46,13 +42,10 @@ public class CastleDeviceTest {
 
         // When
         String payloadJson = model.getGson().toJson(device);
-        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"id\":\"d_id\",\"manufacturer\":\"d_manufacturer\",\"model\":\"d_model\",\"name\":\"d_name\",\"type\":\"d_type\"}";
 
         // Then
-        Assertions.assertThat(convertedObject.get("id").getAsString()).isEqualTo("d_id");
-        Assertions.assertThat(convertedObject.get("manufacturer").getAsString()).isEqualTo("d_manufacturer");
-        Assertions.assertThat(convertedObject.get("model").getAsString()).isEqualTo("d_model");
-        Assertions.assertThat(convertedObject.get("name").getAsString()).isEqualTo("d_name");
-        Assertions.assertThat(convertedObject.get("type").getAsString()).isEqualTo("d_type");
+    Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
     }
 }

--- a/src/test/java/io/castle/client/model/CastleDeviceTest.java
+++ b/src/test/java/io/castle/client/model/CastleDeviceTest.java
@@ -1,6 +1,8 @@
 package io.castle.client.model;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import io.castle.client.internal.json.CastleGsonModel;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -21,9 +23,14 @@ public class CastleDeviceTest {
 
         // When
         String payloadJson = model.getGson().toJson(device);
+        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"id\":\"d_id\",\"manufacturer\":\"d_manufacturer\",\"model\":\"d_model\",\"name\":\"d_name\",\"type\":\"d_type\"}");
+        Assertions.assertThat(convertedObject.get("id").getAsString()).isEqualTo("d_id");
+        Assertions.assertThat(convertedObject.get("manufacturer").getAsString()).isEqualTo("d_manufacturer");
+        Assertions.assertThat(convertedObject.get("model").getAsString()).isEqualTo("d_model");
+        Assertions.assertThat(convertedObject.get("name").getAsString()).isEqualTo("d_name");
+        Assertions.assertThat(convertedObject.get("type").getAsString()).isEqualTo("d_type");
     }
 
     @Test
@@ -39,8 +46,13 @@ public class CastleDeviceTest {
 
         // When
         String payloadJson = model.getGson().toJson(device);
+        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"id\":\"d_id\",\"manufacturer\":\"d_manufacturer\",\"model\":\"d_model\",\"name\":\"d_name\",\"type\":\"d_type\"}");
+        Assertions.assertThat(convertedObject.get("id").getAsString()).isEqualTo("d_id");
+        Assertions.assertThat(convertedObject.get("manufacturer").getAsString()).isEqualTo("d_manufacturer");
+        Assertions.assertThat(convertedObject.get("model").getAsString()).isEqualTo("d_model");
+        Assertions.assertThat(convertedObject.get("name").getAsString()).isEqualTo("d_name");
+        Assertions.assertThat(convertedObject.get("type").getAsString()).isEqualTo("d_type");
     }
 }

--- a/src/test/java/io/castle/client/model/CastleMessageTest.java
+++ b/src/test/java/io/castle/client/model/CastleMessageTest.java
@@ -1,6 +1,7 @@
 package io.castle.client.model;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.castle.client.internal.json.CastleGsonModel;
 import org.assertj.core.api.Assertions;
@@ -31,9 +32,17 @@ public class CastleMessageTest {
 
         // When
         String payloadJson = model.getGson().toJson(message);
+        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"created_at\":\"2018-01-01\",\"timestamp\":\"2018-01-01\",\"device_token\":\"1234\",\"event\":\"event\",\"properties\":{\"key\":\"val\"},\"review_id\":\"2345\",\"user_id\":\"3456\",\"user_traits\":{\"key\":\"val\"}}");
+        Assertions.assertThat(convertedObject.get("created_at").getAsString()).isEqualTo("2018-01-01");
+        Assertions.assertThat(convertedObject.get("timestamp").getAsString()).isEqualTo("2018-01-01");
+        Assertions.assertThat(convertedObject.get("device_token").getAsString()).isEqualTo("1234");
+        Assertions.assertThat(convertedObject.get("event").getAsString()).isEqualTo("event");
+        Assertions.assertThat(convertedObject.get("properties").toString()).isEqualTo("{\"key\":\"val\"}");
+        Assertions.assertThat(convertedObject.get("review_id").getAsString()).isEqualTo("2345");
+        Assertions.assertThat(convertedObject.get("user_id").getAsString()).isEqualTo("3456");
+        Assertions.assertThat(convertedObject.get("user_traits").toString()).isEqualTo("{\"key\":\"val\"}");
     }
 
     @Test
@@ -67,9 +76,17 @@ public class CastleMessageTest {
 
         // When
         String payloadJson = model.getGson().toJson(message);
+        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"created_at\":\"2018-01-01\",\"timestamp\":\"2018-01-01\",\"device_token\":\"1234\",\"event\":\"event\",\"properties\":{\"key\":\"val\"},\"review_id\":\"2345\",\"user_id\":\"3456\",\"user_traits\":{\"key\":\"val\"}}");
+        Assertions.assertThat(convertedObject.get("created_at").getAsString()).isEqualTo("2018-01-01");
+        Assertions.assertThat(convertedObject.get("timestamp").getAsString()).isEqualTo("2018-01-01");
+        Assertions.assertThat(convertedObject.get("device_token").getAsString()).isEqualTo("1234");
+        Assertions.assertThat(convertedObject.get("event").getAsString()).isEqualTo("event");
+        Assertions.assertThat(convertedObject.get("properties").toString()).isEqualTo("{\"key\":\"val\"}");
+        Assertions.assertThat(convertedObject.get("review_id").getAsString()).isEqualTo("2345");
+        Assertions.assertThat(convertedObject.get("user_id").getAsString()).isEqualTo("3456");
+        Assertions.assertThat(convertedObject.get("user_traits").toString()).isEqualTo("{\"key\":\"val\"}");
     }
 
     @Test
@@ -82,8 +99,10 @@ public class CastleMessageTest {
                 .build();
 
         String payloadJson = model.getGson().toJson(message);
+        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
 
-        Assertions.assertThat(payloadJson).isEqualTo("{\"event\":\"event\",\"properties\":{\"key\":\"value\"}}");
+        Assertions.assertThat(convertedObject.get("event").getAsString()).isEqualTo("event");
+        Assertions.assertThat(convertedObject.get("properties").toString()).isEqualTo("{\"key\":\"value\"}");
     }
 
     @Test

--- a/src/test/java/io/castle/client/model/CastleMessageTest.java
+++ b/src/test/java/io/castle/client/model/CastleMessageTest.java
@@ -1,8 +1,8 @@
 package io.castle.client.model;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
@@ -32,17 +32,12 @@ public class CastleMessageTest {
 
         // When
         String payloadJson = model.getGson().toJson(message);
-        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"created_at\":\"2018-01-01\",\"timestamp\":\"2018-01-01\",\"device_token\":\"1234\",\"event\":\"event\",\"properties\":{\"key\":\"val\"},\"review_id\":\"2345\",\"user_id\":\"3456\",\"user_traits\":{\"key\":\"val\"}}";
 
         // Then
-        Assertions.assertThat(convertedObject.get("created_at").getAsString()).isEqualTo("2018-01-01");
-        Assertions.assertThat(convertedObject.get("timestamp").getAsString()).isEqualTo("2018-01-01");
-        Assertions.assertThat(convertedObject.get("device_token").getAsString()).isEqualTo("1234");
-        Assertions.assertThat(convertedObject.get("event").getAsString()).isEqualTo("event");
-        Assertions.assertThat(convertedObject.get("properties").toString()).isEqualTo("{\"key\":\"val\"}");
-        Assertions.assertThat(convertedObject.get("review_id").getAsString()).isEqualTo("2345");
-        Assertions.assertThat(convertedObject.get("user_id").getAsString()).isEqualTo("3456");
-        Assertions.assertThat(convertedObject.get("user_traits").toString()).isEqualTo("{\"key\":\"val\"}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
+
     }
 
     @Test
@@ -76,17 +71,11 @@ public class CastleMessageTest {
 
         // When
         String payloadJson = model.getGson().toJson(message);
-        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"created_at\":\"2018-01-01\",\"timestamp\":\"2018-01-01\",\"device_token\":\"1234\",\"event\":\"event\",\"properties\":{\"key\":\"val\"},\"review_id\":\"2345\",\"user_id\":\"3456\",\"user_traits\":{\"key\":\"val\"}}";
 
         // Then
-        Assertions.assertThat(convertedObject.get("created_at").getAsString()).isEqualTo("2018-01-01");
-        Assertions.assertThat(convertedObject.get("timestamp").getAsString()).isEqualTo("2018-01-01");
-        Assertions.assertThat(convertedObject.get("device_token").getAsString()).isEqualTo("1234");
-        Assertions.assertThat(convertedObject.get("event").getAsString()).isEqualTo("event");
-        Assertions.assertThat(convertedObject.get("properties").toString()).isEqualTo("{\"key\":\"val\"}");
-        Assertions.assertThat(convertedObject.get("review_id").getAsString()).isEqualTo("2345");
-        Assertions.assertThat(convertedObject.get("user_id").getAsString()).isEqualTo("3456");
-        Assertions.assertThat(convertedObject.get("user_traits").toString()).isEqualTo("{\"key\":\"val\"}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
     }
 
     @Test
@@ -99,10 +88,10 @@ public class CastleMessageTest {
                 .build();
 
         String payloadJson = model.getGson().toJson(message);
-        JsonObject convertedObject = new Gson().fromJson(payloadJson, JsonObject.class);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"event\":\"event\",\"properties\":{\"key\":\"value\"}}";
 
-        Assertions.assertThat(convertedObject.get("event").getAsString()).isEqualTo("event");
-        Assertions.assertThat(convertedObject.get("properties").toString()).isEqualTo("{\"key\":\"value\"}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
     }
 
     @Test

--- a/src/test/java/io/castle/client/model/CastleUserAddressTest.java
+++ b/src/test/java/io/castle/client/model/CastleUserAddressTest.java
@@ -1,5 +1,6 @@
 package io.castle.client.model;
 
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -20,8 +21,10 @@ public class CastleUserAddressTest {
 
         // When
         String payloadJson = model.getGson().toJson(address);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"street\":\"street 1\",\"city\":\"city\",\"postal_code\":\"12345\",\"region\":\"region\",\"country\":\"country\"}";
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"street\":\"street 1\",\"city\":\"city\",\"postal_code\":\"12345\",\"region\":\"region\",\"country\":\"country\"}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
     }
 }

--- a/src/test/java/io/castle/client/model/CastleUserDeviceContextTest.java
+++ b/src/test/java/io/castle/client/model/CastleUserDeviceContextTest.java
@@ -1,5 +1,6 @@
 package io.castle.client.model;
 
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import io.castle.client.utils.DeviceUtils;
 import org.assertj.core.api.Assertions;
@@ -44,9 +45,11 @@ public class CastleUserDeviceContextTest {
 
         // When
         String payloadJson = model.getGson().toJson(deviceContext);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"ip\":\"1.1.1.1\",\"user_agent\":{\"raw\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36 OPR/54.0.2952.51\",\"browser\":\"Opera\",\"version\":\"54.0.2952\",\"os\":\"Mac OS X 10.13.6\",\"mobile\":false,\"platform\":\"Mac OS X\",\"device\":\"Unknown\",\"family\":\"Opera\"},\"type\":\"desktop\"}";
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"ip\":\"1.1.1.1\",\"user_agent\":{\"raw\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36 OPR/54.0.2952.51\",\"browser\":\"Opera\",\"version\":\"54.0.2952\",\"os\":\"Mac OS X 10.13.6\",\"mobile\":false,\"platform\":\"Mac OS X\",\"device\":\"Unknown\",\"family\":\"Opera\"},\"type\":\"desktop\"}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
 
         Assert.assertEquals(deviceContext.getIp(), DeviceUtils.CONTEXT_IP);
         Assert.assertEquals(deviceContext.getType(), DeviceUtils.CONTEXT_TYPE);

--- a/src/test/java/io/castle/client/model/CastleUserDeviceTest.java
+++ b/src/test/java/io/castle/client/model/CastleUserDeviceTest.java
@@ -1,6 +1,7 @@
 package io.castle.client.model;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import io.castle.client.utils.DeviceUtils;
 import org.assertj.core.api.Assertions;
@@ -18,9 +19,11 @@ public class CastleUserDeviceTest {
 
         // When
         String payloadJson = model.getGson().toJson(device);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"risk\":0.0,\"is_current_device\":false}";
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"risk\":0.0,\"is_current_device\":false}");
+        Assert.assertEquals(parser.parse(payloadJson), parser.parse(expected));
     }
 
     @Test
@@ -54,9 +57,11 @@ public class CastleUserDeviceTest {
 
         // When
         String payloadJson = model.getGson().toJson(device);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"token\":\"abcdefg12345\",\"risk\":0.0,\"created_at\":\"2018-06-15T16:36:22.916Z\",\"last_seen_at\":\"2018-07-19T23:09:29.681Z\",\"context\":{\"ip\":\"1.1.1.1\",\"user_agent\":{\"raw\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36 OPR/54.0.2952.51\",\"browser\":\"Opera\",\"version\":\"54.0.2952\",\"os\":\"Mac OS X 10.13.6\",\"mobile\":false,\"platform\":\"Mac OS X\",\"device\":\"Unknown\",\"family\":\"Opera\"},\"type\":\"desktop\"},\"is_current_device\":true}";
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"token\":\"abcdefg12345\",\"risk\":0.0,\"created_at\":\"2018-06-15T16:36:22.916Z\",\"last_seen_at\":\"2018-07-19T23:09:29.681Z\",\"context\":{\"ip\":\"1.1.1.1\",\"user_agent\":{\"raw\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36 OPR/54.0.2952.51\",\"browser\":\"Opera\",\"version\":\"54.0.2952\",\"os\":\"Mac OS X 10.13.6\",\"mobile\":false,\"platform\":\"Mac OS X\",\"device\":\"Unknown\",\"family\":\"Opera\"},\"type\":\"desktop\"},\"is_current_device\":true}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
 
         Assert.assertEquals(device.getToken(), DeviceUtils.DEVICE_TOKEN);
         Assert.assertEquals(device.getCreatedAt(), DeviceUtils.DEVICE_CREATED_AT);

--- a/src/test/java/io/castle/client/model/CastleUserDevicesTest.java
+++ b/src/test/java/io/castle/client/model/CastleUserDevicesTest.java
@@ -1,5 +1,6 @@
 package io.castle.client.model;
 
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import io.castle.client.utils.DeviceUtils;
 import org.assertj.core.api.Assertions;
@@ -63,9 +64,11 @@ public class CastleUserDevicesTest {
 
         // When
         String payloadJson = model.getGson().toJson(devices);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"total_count\":1,\"data\":[{\"token\":\"abcdefg12345\",\"risk\":0.0,\"created_at\":\"2018-06-15T16:36:22.916Z\",\"last_seen_at\":\"2018-07-19T23:09:29.681Z\",\"context\":{\"ip\":\"1.1.1.1\",\"user_agent\":{\"raw\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36 OPR/54.0.2952.51\",\"browser\":\"Opera\",\"version\":\"54.0.2952\",\"os\":\"Mac OS X 10.13.6\",\"mobile\":false,\"platform\":\"Mac OS X\",\"device\":\"Unknown\",\"family\":\"Opera\"},\"type\":\"desktop\"},\"is_current_device\":true}]}";
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"total_count\":1,\"data\":[{\"token\":\"abcdefg12345\",\"risk\":0.0,\"created_at\":\"2018-06-15T16:36:22.916Z\",\"last_seen_at\":\"2018-07-19T23:09:29.681Z\",\"context\":{\"ip\":\"1.1.1.1\",\"user_agent\":{\"raw\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36 OPR/54.0.2952.51\",\"browser\":\"Opera\",\"version\":\"54.0.2952\",\"os\":\"Mac OS X 10.13.6\",\"mobile\":false,\"platform\":\"Mac OS X\",\"device\":\"Unknown\",\"family\":\"Opera\"},\"type\":\"desktop\"},\"is_current_device\":true}]}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
 
         Assert.assertEquals(devices.getTotalCount(), devicesList.size());
         Assert.assertEquals(devices.getDevices(), devicesList);

--- a/src/test/java/io/castle/client/model/CastleUserTest.java
+++ b/src/test/java/io/castle/client/model/CastleUserTest.java
@@ -1,5 +1,6 @@
 package io.castle.client.model;
 
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -30,8 +31,10 @@ public class CastleUserTest {
 
         // When
         String payloadJson = model.getGson().toJson(user);
+        JsonParser parser = new JsonParser();
+        String expected = "{\"id\":\"userId\",\"created_at\":\"2019-03-26T11:31:19.968Z\",\"updated_at\":\"2019-03-26T11:31:19.968Z\",\"last_seen_at\":\"d_model\",\"flagged_at\":\"2019-03-26T11:31:19.968Z\",\"risk\":1.1,\"leaks_count\":4,\"devices_count\":2,\"email\":\"test@example.com\",\"name\":\"name\",\"username\":\"username\",\"phone\":\"12345\",\"custom_attributes\":{}}";
 
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"id\":\"userId\",\"created_at\":\"2019-03-26T11:31:19.968Z\",\"updated_at\":\"2019-03-26T11:31:19.968Z\",\"last_seen_at\":\"d_model\",\"flagged_at\":\"2019-03-26T11:31:19.968Z\",\"risk\":1.1,\"leaks_count\":4,\"devices_count\":2,\"email\":\"test@example.com\",\"name\":\"name\",\"username\":\"username\",\"phone\":\"12345\",\"custom_attributes\":{}}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
     }
 }

--- a/src/test/java/io/castle/client/model/DeviceUserAgentTest.java
+++ b/src/test/java/io/castle/client/model/DeviceUserAgentTest.java
@@ -1,5 +1,6 @@
 package io.castle.client.model;
 
+import com.google.gson.JsonParser;
 import io.castle.client.internal.json.CastleGsonModel;
 import io.castle.client.utils.DeviceUtils;
 import org.assertj.core.api.Assertions;
@@ -36,9 +37,10 @@ public class DeviceUserAgentTest {
 
         // When
         String payloadJson = model.getGson().toJson(userAgent);
-
+        JsonParser parser = new JsonParser();
+        String expected = "{\"raw\":\"Mac OS X\",\"browser\":\"Opera\",\"version\":\"Mac OS X\",\"os\":\"Mac OS X 10.13.6\",\"mobile\":false,\"platform\":\"Mac OS X\",\"device\":\"Unknown\",\"family\":\"Opera\"}";
         // Then
-        Assertions.assertThat(payloadJson).isEqualTo("{\"raw\":\"Mac OS X\",\"browser\":\"Opera\",\"version\":\"Mac OS X\",\"os\":\"Mac OS X 10.13.6\",\"mobile\":false,\"platform\":\"Mac OS X\",\"device\":\"Unknown\",\"family\":\"Opera\"}");
+        Assertions.assertThat(parser.parse(payloadJson)).isEqualTo(parser.parse(expected));
 
         Assert.assertEquals(userAgent.getBrowser(), DeviceUtils.USER_AGENT_BROWSER);
         Assert.assertEquals(userAgent.getDevice(), DeviceUtils.USER_AGENT_DEVICE);


### PR DESCRIPTION
## Description of the problem
These tests are found flaky:
```
io.castle.client.model.CastleContextTest.minimalContextAsJson
io.castle.client.model.CastleDeviceTest.fullBuilderJson
io.castle.client.model.CastleDeviceTest.jsonSerialized
io.castle.client.model.CastleMessageTest.fullBuilderJson
io.castle.client.model.CastleMessageTest.jsonSerialized
io.castle.client.model.CastleMessageTest.properties
io.castle.client.model.CastleUserAddressTest.jsonSerialized
io.castle.client.model.CastleUserDeviceContextTest.fullBuilderJson
io.castle.client.model.CastleUserDevicesTest.fullBuilderJson
io.castle.client.model.CastleUserDeviceTest.fullBuilderJson
io.castle.client.model.CastleUserDeviceTest.jsonSerialized
io.castle.client.model.CastleUserTest.jsonSerialized
io.castle.client.model.DeviceUserAgentTest.fullBuilderJson
```
when running `mvn -pl ./ edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=TESTNAME `.

Here is an example of the error log:

```
[ERROR] Failures:

[ERROR]   CastleMessageTest.fullBuilderJson:72 expected:<"{"[created_at":"2018-01-01","timestamp":"2018-01-01","device_token":"1234","event":"event","properties":{"key":"val"},"review_id":"2345","user_id":"3456","user_traits":{"key":"val"}]}"> but was:<"{"[user_id":"3456","user_traits":{"key":"val"},"timestamp":"2018-01-01","review_id":"2345","properties":{"key":"val"},"event":"event","device_token":"1234","created_at":"2018-01-01"]}">
```
## Cause of Flaky
The reason of the flaky tests is because the `Gson()` library. It can not guarantee the order of the generated string when calling `Gson.toJson()`, it shuffles the order for each `NonDex` run.

## What I have changed
To avoid the flakiness, I change the testing logic from comparing the hard coded  string to comparing the expected and actual value as `JsonObject` by using `JsonParser()`. In this case, the order will be ignored and two `jsonObject` will be compared, to avoid the flakiness.