### PR TITLE
Serialize null values in ChangesetEntry

### DIFF
--- a/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
+++ b/src/main/java/io/castle/client/internal/backend/OkHttpFactory.java
@@ -7,7 +7,6 @@ import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 public class OkHttpFactory implements RestApiFactory {

--- a/src/main/java/io/castle/client/internal/backend/OkRestApiBackend.java
+++ b/src/main/java/io/castle/client/internal/backend/OkRestApiBackend.java
@@ -1,6 +1,5 @@
 package io.castle.client.internal.backend;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.*;
 import io.castle.client.Castle;
 import io.castle.client.internal.config.CastleConfiguration;

--- a/src/main/java/io/castle/client/internal/backend/RestApi.java
+++ b/src/main/java/io/castle/client/internal/backend/RestApi.java
@@ -1,10 +1,8 @@
 package io.castle.client.internal.backend;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.castle.client.model.*;
-import okhttp3.Response;
 
 public interface RestApi {
 

--- a/src/main/java/io/castle/client/internal/json/CastleGsonModel.java
+++ b/src/main/java/io/castle/client/internal/json/CastleGsonModel.java
@@ -31,6 +31,7 @@ public class CastleGsonModel {
         builder.registerTypeAdapter(CastleHeaders.class, new CastleHeadersDeserializer());
         builder.registerTypeAdapter(AuthenticateAction.class, new AuthenticateActionDeserializer());
         builder.registerTypeAdapter(RiskPolicyType.class, new RiskPolicyTypeDeserializer());
+        builder.registerTypeAdapterFactory(ChangesetEntryTypeAdapter.FACTORY);
 
         builder.registerTypeAdapter(Date.class, new DateTypeAdapter());
         builder.registerTypeAdapter(java.sql.Date.class, new SqlDateTypeAdapter());

--- a/src/main/java/io/castle/client/internal/json/CastleGsonModel.java
+++ b/src/main/java/io/castle/client/internal/json/CastleGsonModel.java
@@ -1,7 +1,6 @@
 package io.castle.client.internal.json;
 
 import com.google.gson.*;
-import com.google.gson.internal.bind.DateTypeAdapter;
 import com.google.gson.internal.bind.util.ISO8601Utils;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;

--- a/src/main/java/io/castle/client/internal/json/ChangesetEntryTypeAdapter.java
+++ b/src/main/java/io/castle/client/internal/json/ChangesetEntryTypeAdapter.java
@@ -1,0 +1,44 @@
+package io.castle.client.internal.json;
+
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.*;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import io.castle.client.model.generated.ChangesetEntry;
+
+import java.io.IOException;
+
+public class ChangesetEntryTypeAdapter extends TypeAdapter<ChangesetEntry> {
+    static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
+      @SuppressWarnings("unchecked")
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        if (type.getRawType() != ChangesetEntry.class) {
+          return null;
+        }
+        TypeAdapter<ChangesetEntry> delegate = (TypeAdapter<ChangesetEntry>) gson.getDelegateAdapter(this, type);
+        return (TypeAdapter<T>) new ChangesetEntryTypeAdapter(delegate);
+      }
+    };
+  
+    private final TypeAdapter<ChangesetEntry> delegate;
+  
+    ChangesetEntryTypeAdapter(TypeAdapter<ChangesetEntry> delegate) {
+      this.delegate = delegate;
+    }
+  
+    @Override public void write(JsonWriter out, ChangesetEntry value) throws IOException {
+      boolean serializeNulls = out.getSerializeNulls();
+      out.setSerializeNulls(true);
+      try {
+        delegate.write(out, value);
+      } finally {
+        out.setSerializeNulls(serializeNulls);
+      }
+    }
+  
+    @Override public ChangesetEntry read(JsonReader in) throws IOException {
+      return delegate.read(in);
+    }
+  }

--- a/src/test/java/io/castle/client/CastleRiskHttpTest.java
+++ b/src/test/java/io/castle/client/CastleRiskHttpTest.java
@@ -75,7 +75,7 @@ public class CastleRiskHttpTest extends AbstractCastleHttpLayerTest {
 
         Changeset changeSet = new Changeset()
                 .email(new ChangesetEntry()
-                        .from("before@exmaple.com")
+                        .from(null)
                         .to("after@example.com"))
                 .password(new ChangedChangesetEntry())
                 .authenticationMethodType(new ChangesetEntry()
@@ -114,7 +114,7 @@ public class CastleRiskHttpTest extends AbstractCastleHttpLayerTest {
 
         String body = recordedRequest.getBody().readUtf8();
 
-        String expected = "{\"context\":{\"headers\":[[\"User-Agent\",\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15\"]],\"ip\":\"211.96.77.55\"},\"properties\":{\"property2\":{},\"property1\":{}},\"product\":{\"id\":\"1234\"},\"created_at\":\"2022-05-20T09:03:27.468+02:00\",\"request_token\":\"4-ugt5CFooaxt5KbpISi1Kurm5KTpqawlYmFs5PXsqKootPgRB3z12OpvPOWOQ9PkztagtqicAnk9Qowu7FlU9qabyi4k2QR6KUUL5p3gr-A2w8Ju8gWe0XyRi_OkmFj2oZiU9OTPAjijjIK4sA-a7f19GC_xzhYurdkWM-ZY1jR_l4R8JloVdGTfj7IhXY6_pd5SNGThjmM2DoSjWNup74xC3v-l3lI0ZMlDZPGJAyd3jsVnd5JXc6CZlmdxSQMk8UxHPyYbk7Sn24cjMQxHPqZZVvRkypP2Z1VW82eZVLYwD5jxc48Y4vCI4C1gDJWiIVMXssRDTmrPME9aeZPSc-ZelmSpX5T3p1iU9Gb1jnYmCdp7gnJ\",\"user\":{\"id\":\"12345\"},\"skip_request_token_validation\":false,\"skip_context_validation\":false,\"type\":\"$profile_update\",\"status\":\"$succeeded\",\"changeset\":{\"password\":{\"changed\":true},\"email\":{\"from\":\"before@exmaple.com\",\"to\":\"after@example.com\"},\"authentication_method.type\":{\"from\":\"$authenticator\",\"to\":\"$email\"},\"name\":{\"from\":\"Jon Snow\",\"to\":\"King of the North\"}}}";
+        String expected = "{\"context\":{\"headers\":[[\"User-Agent\",\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15\"]],\"ip\":\"211.96.77.55\"},\"properties\":{\"property2\":{},\"property1\":{}},\"product\":{\"id\":\"1234\"},\"created_at\":\"2022-05-20T09:03:27.468+02:00\",\"request_token\":\"4-ugt5CFooaxt5KbpISi1Kurm5KTpqawlYmFs5PXsqKootPgRB3z12OpvPOWOQ9PkztagtqicAnk9Qowu7FlU9qabyi4k2QR6KUUL5p3gr-A2w8Ju8gWe0XyRi_OkmFj2oZiU9OTPAjijjIK4sA-a7f19GC_xzhYurdkWM-ZY1jR_l4R8JloVdGTfj7IhXY6_pd5SNGThjmM2DoSjWNup74xC3v-l3lI0ZMlDZPGJAyd3jsVnd5JXc6CZlmdxSQMk8UxHPyYbk7Sn24cjMQxHPqZZVvRkypP2Z1VW82eZVLYwD5jxc48Y4vCI4C1gDJWiIVMXssRDTmrPME9aeZPSc-ZelmSpX5T3p1iU9Gb1jnYmCdp7gnJ\",\"user\":{\"id\":\"12345\"},\"skip_request_token_validation\":false,\"skip_context_validation\":false,\"type\":\"$profile_update\",\"status\":\"$succeeded\",\"changeset\":{\"password\":{\"changed\":true},\"email\":{\"from\":null,\"to\":\"after@example.com\"},\"authentication_method.type\":{\"from\":\"$authenticator\",\"to\":\"$email\"},\"name\":{\"from\":\"Jon Snow\",\"to\":\"King of the North\"}}}";
         Assertions.assertThat(JsonParser.parseString(body)).isEqualTo(JsonParser.parseString(expected));
     }
 

--- a/src/test/java/io/castle/client/model/CastleMessageTest.java
+++ b/src/test/java/io/castle/client/model/CastleMessageTest.java
@@ -101,7 +101,7 @@ public class CastleMessageTest {
 
         Assertions.assertThat(payloadJson).isEqualTo("{\"event\":\"event\",\"key\":\"value\"}");
 
-        HashMap other = new HashMap();
+        HashMap<String, String> other = new HashMap<String, String>();
         other.put("key", "value");
 
         message = CastleMessage.builder("event")


### PR DESCRIPTION
This PR fixes an issue where the API expects the `to` value of the `changeset` options to be explicitly set to `null` rather than the key being omitted. 