### PR TITLE
Proposals: isolate the Servlet API, lower the build target, and add a Fern scaffold

### DIFF
--- a/fern/README.md
+++ b/fern/README.md
@@ -1,0 +1,23 @@
+# Fern scaffold (proposal)
+
+This directory is a proposal for generating the Castle Java SDK surface with
+[Fern](https://buildwithfern.com) from an OpenAPI specification.
+
+## Layout
+
+- `fern.config.json` — organization name and pinned Fern CLI version.
+- `generators.yml` — declares the API spec and the `fern-java-sdk` generator group.
+- `openapi/openapi.yml` — OpenAPI spec for the Castle scoring, Lists, Privacy
+  and Events endpoints used as the generator input.
+
+## Usage
+
+```bash
+npm install -g fern-api
+fern check
+fern generate --group java-sdk --local
+```
+
+Generated code is written to `../generated/java` and is not committed. The
+generated client is namespaced under `io.castle.client.generated` so it can be
+adopted incrementally alongside the hand-written client.

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "castle",
+  "version": "5.47.1"
+}

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -1,0 +1,15 @@
+api:
+  specs:
+    - openapi: ./openapi/openapi.yml
+groups:
+  java-sdk:
+    generators:
+      - name: fernapi/fern-java-sdk
+        version: 4.9.3
+        output:
+          location: local-file-system
+          path: ../generated/java
+        github:
+          repository: castle/castle-java
+        config:
+          package-prefix: io.castle.client.generated

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -1,0 +1,240 @@
+openapi: 3.0.3
+info:
+  title: Castle API
+  version: "1.0.0"
+  description: >
+    Server-side Castle API covering the scoring endpoints (risk, filter, log),
+    the Lists and Privacy management endpoints, and the Events API. This
+    specification is the input for Fern SDK generation.
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: https://api.castle.io/v1
+security:
+  - apiSecret: []
+tags:
+  - name: Scoring
+  - name: Lists
+  - name: Privacy
+  - name: Events
+paths:
+  /risk:
+    post:
+      operationId: risk
+      tags: [Scoring]
+      summary: Evaluate the risk of an authenticated event.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScoringRequest"
+      responses:
+        "200":
+          description: Verdict for the evaluated event.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Verdict"
+  /filter:
+    post:
+      operationId: filter
+      tags: [Scoring]
+      summary: Evaluate the risk of an unauthenticated event.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScoringRequest"
+      responses:
+        "200":
+          description: Verdict for the evaluated event.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Verdict"
+  /log:
+    post:
+      operationId: log
+      tags: [Scoring]
+      summary: Log an event without scoring it.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScoringRequest"
+      responses:
+        "200":
+          description: The logged event was accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+  /lists:
+    get:
+      operationId: listAllLists
+      tags: [Lists]
+      summary: Return all lists.
+      responses:
+        "200":
+          description: The available lists.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/List"
+    post:
+      operationId: createList
+      tags: [Lists]
+      summary: Create a list.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListRequest"
+      responses:
+        "201":
+          description: The created list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/List"
+  /privacy/users:
+    post:
+      operationId: requestUserData
+      tags: [Privacy]
+      summary: Request a data export for a user.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PrivacyRequest"
+      responses:
+        "200":
+          description: The privacy request was accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+    delete:
+      operationId: deleteUserData
+      tags: [Privacy]
+      summary: Request deletion of a user's data.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PrivacyRequest"
+      responses:
+        "200":
+          description: The deletion request was accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+  /events/schema:
+    get:
+      operationId: eventsSchema
+      tags: [Events]
+      summary: Return the event schema for the account.
+      responses:
+        "200":
+          description: The event schema.
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  securitySchemes:
+    apiSecret:
+      type: http
+      scheme: basic
+      description: HTTP Basic auth with the API secret as the username and an empty password.
+  schemas:
+    ScoringRequest:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+          example: "$login"
+        status:
+          type: string
+          example: "$succeeded"
+        request_token:
+          type: string
+        user:
+          $ref: "#/components/schemas/User"
+        properties:
+          type: object
+          additionalProperties: true
+        context:
+          type: object
+          additionalProperties: true
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+        traits:
+          type: object
+          additionalProperties: true
+    Verdict:
+      type: object
+      properties:
+        risk:
+          type: number
+          format: double
+        policy:
+          $ref: "#/components/schemas/Policy"
+        signals:
+          type: object
+          additionalProperties: true
+        failover:
+          type: boolean
+        failover_reason:
+          type: string
+    Policy:
+      type: object
+      properties:
+        action:
+          type: string
+          enum: [allow, challenge, deny]
+        name:
+          type: string
+        id:
+          type: string
+    List:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        color:
+          type: string
+    ListRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+    PrivacyRequest:
+      type: object
+      required: [user_id]
+      properties:
+        user_id:
+          type: string

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdkVersion>17</jdkVersion>
-        <targetJdk>17</targetJdk>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <jdkVersion>11</jdkVersion>
+        <targetJdk>11</targetJdk>
         <jacoco.version>0.8.15</jacoco.version>
+        <!-- Reflection access flags required by the test toolchain on JDK 11+. -->
+        <surefire.argLine.jdk></surefire.argLine.jdk>
     </properties>
 
     <profiles>
+        <profile>
+            <id>jdk11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <surefire.argLine.jdk>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</surefire.argLine.jdk>
+            </properties>
+        </profile>
         <profile>
             <id>deploy</id>
             <build>
@@ -221,8 +234,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                     <optimize>true</optimize>
                     <debug>true</debug>
                 </configuration>
@@ -263,7 +276,7 @@
                 <version>3.1.2</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <argLine>@{argLine} ${surefire.argLine.jdk}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <version>6.0.0</version>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/src/main/java/io/castle/client/Castle.java
+++ b/src/main/java/io/castle/client/Castle.java
@@ -296,10 +296,7 @@ public class Castle {
      * @return {@code true} when the signature matches the computed signature
      */
     public boolean verifyWebhookSignature(HttpServletRequest request, byte[] body) {
-        if (request == null) {
-            return false;
-        }
-        return verifyWebhookSignature(request.getHeader(WEBHOOK_SIGNATURE_HEADER), body);
+        return io.castle.client.servlet.CastleServletContext.verifyWebhookSignature(this, request, body);
     }
 
     /**

--- a/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
+++ b/src/main/java/io/castle/client/internal/utils/CastleContextBuilder.java
@@ -4,13 +4,10 @@ import io.castle.client.internal.config.CastleConfiguration;
 import io.castle.client.internal.json.CastleGsonModel;
 import io.castle.client.model.CastleContext;
 import io.castle.client.model.CastleDevice;
-import io.castle.client.model.CastleHeader;
 import io.castle.client.model.CastleHeaders;
+import io.castle.client.servlet.CastleServletContext;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.Enumeration;
 
 public class CastleContextBuilder {
 
@@ -18,7 +15,6 @@ public class CastleContextBuilder {
     private CastleHeaders headers;
     private final CastleGsonModel model;
     private final CastleConfiguration configuration;
-    private final HeaderNormalizer headerNormalizer = new HeaderNormalizer();
 
     public CastleContextBuilder(CastleConfiguration configuration, CastleGsonModel model) {
         this.configuration = configuration;
@@ -71,21 +67,18 @@ public class CastleContextBuilder {
         return this;
     }
 
+    /**
+     * Populate the builder from a servlet request.
+     * <p>
+     * Delegates to {@link CastleServletContext}, which holds the only references to
+     * the Servlet API. Consumers on other stacks can use {@link #ip(String)},
+     * {@link #headers(CastleHeaders)} and {@link #userAgent(String)} directly.
+     *
+     * @param request the incoming servlet request
+     * @return this builder, for chaining
+     */
     public CastleContextBuilder fromHttpServletRequest(HttpServletRequest request) {
-        context.setClientId(setClientIdFromHttpServletRequest(request));
-        this.headers = setCastleHeadersFromHttpServletRequest(request);
-        context.setUserAgent(setUserAgentFromHttpServletRequest(request));
-
-        context.setIp(request.getRemoteAddr());
-        if (configuration.getIpHeaders() != null) {
-            for (String header : configuration.getIpHeaders()) {
-                if (request.getHeader(header) != null) {
-                    context.setIp(request.getHeader(header));
-                    break;
-                }
-            }
-        }
-        return this;
+        return CastleServletContext.populate(this, configuration, request);
     }
 
     public CastleContextBuilder fromJson(String contextString) {
@@ -96,93 +89,6 @@ public class CastleContextBuilder {
 
     public String toJson() {
         return model.getGson().toJson(build());
-    }
-
-    /**
-     * Load the headers from the HttpRequest.
-     * A header will be passed only when it is not on the denylist and it appears on the allowlist
-     *
-     * @param request The HttpRequest containing the headers.
-     * @return headers Model for castle backend.
-     */
-    private CastleHeaders setCastleHeadersFromHttpServletRequest(HttpServletRequest request) {
-        ArrayList<CastleHeader> castleHeadersList = new ArrayList<>();
-        for (Enumeration<String> headerNames = request.getHeaderNames(); headerNames.hasMoreElements(); ) {
-            String key = headerNames.nextElement();
-            String headerValue = request.getHeader(key);
-            addHeaderValue(castleHeadersList, key, headerValue);
-        }
-        //A CGI specific header is added for compliance with other castle sdk libraries
-        addHeaderValue(castleHeadersList, "REMOTE_ADDR",request.getRemoteAddr());
-
-        CastleHeaders headers = new CastleHeaders();
-        headers.setHeaders(castleHeadersList);
-        return headers;
-    }
-
-    private void addHeaderValue(ArrayList<CastleHeader> castleHeadersList, String key, String headerValue) {
-        String keyNormalized = headerNormalizer.normalize(key);
-        if (configuration.getDenyListHeaders().contains(keyNormalized)) {
-            // Scrub header since it is denylisted
-            castleHeadersList.add(new CastleHeader(key, "true"));
-            return;
-        }
-
-        // No allowList set, everything is allowListed
-        if (configuration.getAllowListHeaders().isEmpty()) {
-            castleHeadersList.add(new CastleHeader(key, headerValue));
-        } else if (configuration.getAllowListHeaders().contains(keyNormalized)) {
-            castleHeadersList.add(new CastleHeader(key, headerValue));
-        } else {
-            // Add scrubbed header
-            castleHeadersList.add(new CastleHeader(key, "true"));
-        }
-    }
-
-    /**
-     * Extract the clientId from the request.
-     * If header 'X-Castle-Client-Id' is set use that value, if not use __cid cookie, if none is set default to false
-     * @param request HttpServletRequest to extract clientId from
-     * @return a string clientId or false
-     */
-    private Object setClientIdFromHttpServletRequest(HttpServletRequest request) {
-        String cid = request.getHeader("X-Castle-Client-Id");
-
-        // If client id header is not included, check cookie
-        if (cid == null || cid.isEmpty()) {
-            Cookie[] cookies = request.getCookies();
-            if (cookies != null) {
-                for (Cookie cookie : cookies) {
-                    if (cookie.getName().equals("__cid")) {
-                        cid = cookie.getValue();
-                    }
-                }
-            }
-        }
-
-        // If cid could not be extracted, default to false
-        if (cid == null) {
-            return false;
-        }
-
-        return cid;
-    }
-
-    /**
-     * Extract the User Agent from the request.
-     * If header 'User-Agent' is set use that value, if not default to false
-     * @param request HttpServletRequest to extract User Agent from
-     * @return a string User Agent or false
-     */
-    private Object setUserAgentFromHttpServletRequest(HttpServletRequest request) {
-        String userAgent = request.getHeader("User-Agent");
-
-        // If User Agent header is not present, default to false
-        if (userAgent == null) {
-            return false;
-        }
-
-        return userAgent;
     }
 
 }

--- a/src/main/java/io/castle/client/servlet/CastleServletContext.java
+++ b/src/main/java/io/castle/client/servlet/CastleServletContext.java
@@ -1,0 +1,177 @@
+package io.castle.client.servlet;
+
+import io.castle.client.Castle;
+import io.castle.client.internal.config.CastleConfiguration;
+import io.castle.client.internal.json.CastleGsonModel;
+import io.castle.client.internal.utils.CastleContextBuilder;
+import io.castle.client.internal.utils.HeaderNormalizer;
+import io.castle.client.model.CastleContext;
+import io.castle.client.model.CastleHeader;
+import io.castle.client.model.CastleHeaders;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Enumeration;
+
+/**
+ * Servlet integration helper.
+ * <p>
+ * Reads the request context (IP, headers, user agent, client id) and the
+ * webhook signature header from a {@code jakarta.servlet.http.HttpServletRequest}
+ * and feeds them into the framework-agnostic SDK surface
+ * ({@link CastleContextBuilder} and {@link Castle#verifyWebhookSignature(String, byte[])}).
+ * <p>
+ * Every reference to the Servlet API is contained in this class. Consumers on a
+ * different stack (plain {@code byte[]} bodies, JAX-RS, {@code javax.servlet},
+ * non-servlet frameworks) can build the context and verify webhooks without it.
+ */
+public final class CastleServletContext {
+
+    private static final HeaderNormalizer HEADER_NORMALIZER = new HeaderNormalizer();
+
+    private final CastleConfiguration configuration;
+    private final CastleGsonModel model;
+
+    public CastleServletContext(CastleConfiguration configuration, CastleGsonModel model) {
+        this.configuration = configuration;
+        this.model = model;
+    }
+
+    /**
+     * Build a populated context builder from a servlet request.
+     *
+     * @param request the incoming servlet request
+     * @return a {@link CastleContextBuilder} with IP, headers, user agent and client id applied
+     */
+    public CastleContextBuilder builder(HttpServletRequest request) {
+        return populate(new CastleContextBuilder(configuration, model), configuration, request);
+    }
+
+    /**
+     * Build a {@link CastleContext} from a servlet request.
+     *
+     * @param request the incoming servlet request
+     * @return the populated context
+     */
+    public CastleContext toContext(HttpServletRequest request) {
+        return builder(request).build();
+    }
+
+    /**
+     * Apply the values extracted from a servlet request onto an existing builder.
+     *
+     * @param builder       the builder to populate
+     * @param configuration the active SDK configuration (drives IP headers and allow/deny lists)
+     * @param request       the incoming servlet request
+     * @return the same builder, for chaining
+     */
+    public static CastleContextBuilder populate(CastleContextBuilder builder, CastleConfiguration configuration, HttpServletRequest request) {
+        Object clientId = extractClientId(request);
+        if (clientId instanceof String) {
+            builder.clientId((String) clientId);
+        } else {
+            builder.clientId(false);
+        }
+
+        builder.headers(extractHeaders(configuration, request));
+
+        Object userAgent = extractUserAgent(request);
+        if (userAgent instanceof String) {
+            builder.userAgent((String) userAgent);
+        } else {
+            builder.userAgent(false);
+        }
+
+        builder.ip(extractIp(configuration, request));
+        return builder;
+    }
+
+    /**
+     * Read the {@code X-Castle-Signature} header from a servlet request and verify it
+     * against the supplied raw request body.
+     *
+     * @param castle  an initialized SDK instance
+     * @param request the incoming webhook request
+     * @param body    the raw request body bytes
+     * @return {@code true} when the signature matches the computed signature
+     */
+    public static boolean verifyWebhookSignature(Castle castle, HttpServletRequest request, byte[] body) {
+        if (request == null) {
+            return false;
+        }
+        return castle.verifyWebhookSignature(request.getHeader(Castle.WEBHOOK_SIGNATURE_HEADER), body);
+    }
+
+    public static String extractIp(CastleConfiguration configuration, HttpServletRequest request) {
+        if (configuration.getIpHeaders() != null) {
+            for (String header : configuration.getIpHeaders()) {
+                if (request.getHeader(header) != null) {
+                    return request.getHeader(header);
+                }
+            }
+        }
+        return request.getRemoteAddr();
+    }
+
+    public static CastleHeaders extractHeaders(CastleConfiguration configuration, HttpServletRequest request) {
+        ArrayList<CastleHeader> castleHeadersList = new ArrayList<>();
+        for (Enumeration<String> headerNames = request.getHeaderNames(); headerNames.hasMoreElements(); ) {
+            String key = headerNames.nextElement();
+            addHeaderValue(configuration, castleHeadersList, key, request.getHeader(key));
+        }
+        // A CGI specific header is added for compliance with other Castle SDK libraries
+        addHeaderValue(configuration, castleHeadersList, "REMOTE_ADDR", request.getRemoteAddr());
+
+        CastleHeaders headers = new CastleHeaders();
+        headers.setHeaders(castleHeadersList);
+        return headers;
+    }
+
+    private static void addHeaderValue(CastleConfiguration configuration, ArrayList<CastleHeader> castleHeadersList, String key, String headerValue) {
+        String keyNormalized = HEADER_NORMALIZER.normalize(key);
+        if (configuration.getDenyListHeaders().contains(keyNormalized)) {
+            castleHeadersList.add(new CastleHeader(key, "true"));
+            return;
+        }
+
+        if (configuration.getAllowListHeaders().isEmpty()) {
+            castleHeadersList.add(new CastleHeader(key, headerValue));
+        } else if (configuration.getAllowListHeaders().contains(keyNormalized)) {
+            castleHeadersList.add(new CastleHeader(key, headerValue));
+        } else {
+            castleHeadersList.add(new CastleHeader(key, "true"));
+        }
+    }
+
+    public static Object extractClientId(HttpServletRequest request) {
+        String cid = request.getHeader("X-Castle-Client-Id");
+
+        if (cid == null || cid.isEmpty()) {
+            Cookie[] cookies = request.getCookies();
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    if (cookie.getName().equals("__cid")) {
+                        cid = cookie.getValue();
+                    }
+                }
+            }
+        }
+
+        if (cid == null) {
+            return false;
+        }
+
+        return cid;
+    }
+
+    public static Object extractUserAgent(HttpServletRequest request) {
+        String userAgent = request.getHeader("User-Agent");
+
+        if (userAgent == null) {
+            return false;
+        }
+
+        return userAgent;
+    }
+}

--- a/src/test/java/io/castle/client/servlet/CastleServletContextTest.java
+++ b/src/test/java/io/castle/client/servlet/CastleServletContextTest.java
@@ -1,0 +1,103 @@
+package io.castle.client.servlet;
+
+import io.castle.client.Castle;
+import io.castle.client.internal.config.CastleConfiguration;
+import io.castle.client.internal.config.CastleConfigurationBuilder;
+import io.castle.client.internal.json.CastleGsonModel;
+import io.castle.client.internal.utils.Webhook;
+import io.castle.client.model.CastleContext;
+import io.castle.client.model.CastleHeaders;
+import io.castle.client.model.CastleSdkConfigurationException;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class CastleServletContextTest {
+
+    private static final String SECRET = "test_api_secret";
+
+    private final CastleGsonModel model = new CastleGsonModel();
+
+    private CastleConfiguration configuration() throws CastleSdkConfigurationException {
+        return CastleConfigurationBuilder
+                .defaultConfigBuilder()
+                .withApiSecret("anyValidKey")
+                .withCastleAppId("anyValidAppId")
+                .build();
+    }
+
+    @Test
+    public void buildsContextFromServletRequest() throws CastleSdkConfigurationException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("8.8.8.8");
+        request.addHeader("User-Agent", "agent");
+        request.addHeader("Accept", "text/html");
+
+        CastleContext context = new CastleServletContext(configuration(), model).toContext(request);
+
+        Assertions.assertThat(context.getIp()).isEqualTo("8.8.8.8");
+        Assertions.assertThat(context.getUserAgent()).isEqualTo("agent");
+        Assertions.assertThat(context.getClientId()).isEqualTo(false);
+    }
+
+    @Test
+    public void resolvesIpFromConfiguredHeaders() throws CastleSdkConfigurationException {
+        CastleConfiguration configuration = CastleConfigurationBuilder.defaultConfigBuilder()
+                .apiSecret("abcd")
+                .ipHeaders(Arrays.asList("X-Forwarded-For", "CF-Connecting-IP"))
+                .build();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("8.8.8.8");
+        request.addHeader("X-Forwarded-For", "1.1.1.1,2.2.2.2");
+        request.addHeader("CF-Connecting-IP", "4.4.4.4");
+
+        CastleContext context = new CastleServletContext(configuration, model).toContext(request);
+
+        Assertions.assertThat(context.getIp()).isEqualTo("1.1.1.1,2.2.2.2");
+    }
+
+    @Test
+    public void servletAndManualBuildersProduceSameContext() throws CastleSdkConfigurationException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("8.8.8.8");
+        request.addHeader("User-Agent", "agent");
+
+        CastleContext servletContext = new CastleServletContext(configuration(), model).toContext(request);
+
+        CastleHeaders headers = CastleHeaders.builder()
+                .add("User-Agent", "agent")
+                .add("REMOTE_ADDR", "8.8.8.8")
+                .build();
+        CastleContext manualContext = new io.castle.client.internal.utils.CastleContextBuilder(configuration(), model)
+                .userAgent("agent")
+                .headers(headers)
+                .ip("8.8.8.8")
+                .clientId(false)
+                .build();
+
+        Assertions.assertThat(servletContext).usingRecursiveComparison().isEqualTo(manualContext);
+    }
+
+    @Test
+    public void verifiesWebhookSignatureFromServletRequest() throws CastleSdkConfigurationException {
+        Castle sdk = Castle.verifySdkConfigurationAndInitialize();
+        byte[] body = "{\"type\":\"$review.opened\"}".getBytes(StandardCharsets.UTF_8);
+        String signature = Webhook.computeSignature(SECRET, body);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(Castle.WEBHOOK_SIGNATURE_HEADER, signature);
+
+        Assertions.assertThat(CastleServletContext.verifyWebhookSignature(sdk, request, body)).isTrue();
+        Assertions.assertThat(sdk.verifyWebhookSignature(request, body)).isTrue();
+    }
+
+    @Test
+    public void rejectsNullServletRequest() throws CastleSdkConfigurationException {
+        Castle sdk = Castle.verifySdkConfigurationAndInitialize();
+        Assertions.assertThat(CastleServletContext.verifyWebhookSignature(sdk, null, new byte[0])).isFalse();
+    }
+}


### PR DESCRIPTION
Proposal set, each in its own commit. Opened as a draft for review.

## Isolate the Servlet API behind a dedicated helper
- Add `io.castle.client.servlet.CastleServletContext`, which holds every `jakarta.servlet` reference and exposes servlet context building (`builder` / `toContext`) and a `verifyWebhookSignature(Castle, HttpServletRequest, byte[])` helper.
- `CastleContextBuilder.fromHttpServletRequest` and `Castle.verifyWebhookSignature(HttpServletRequest, byte[])` delegate to the helper; the core no longer carries the servlet extraction logic.
- Mark the `jakarta.servlet-api` dependency `optional`.
- Add `CastleServletContextTest` covering context extraction, configured IP-header resolution, equivalence with the manual `ip` / `headers` / `userAgent` builder surface, and webhook verification.

## Lower the compile target to Java 11 and add JDK-version build profiles
- Set `source`/`target` to 11.
- Add a `jdk11-plus` Maven profile that supplies the `--add-opens` reflection flags only on JDK 11+, replacing the static surefire `argLine`.

## Add a Fern SDK generator scaffold
- Add `fern/` with `fern.config.json`, `generators.yml` (the `fern-java-sdk` generator group), and `openapi/openapi.yml` describing the scoring, Lists, Privacy and Events endpoints.
- Generated output is namespaced under `io.castle.client.generated` and is not committed.